### PR TITLE
Add unified benchmark report generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,11 +200,20 @@ python scripts/process_local_video.py --input input.mp4 --output out.mp4 --promp
 
 ### Run performance benchmark
 
-This will show throughput (FPS) with various dynamic area values and end-to-end latency.
-The generated benchmark report will include the current configuration and hardware parameters.
+This generates a unified Markdown benchmark report for the synthetic dynamic-area workload.
+The report includes base FPS, interpolated FPS, interpolation counts, VRAM, selected config metadata, environment information, and the legacy end-to-end latency probe.
 
 ```bash
-python scripts/run_benchmark.py
+python scripts/run_benchmark.py --no-window --output benchmark_report.md
+```
+
+Base FPS is generated-frame throughput before interpolation. Interpolated FPS applies the configured interpolation multiplier (`2 ** interpolation_exp`), for example `interpolation_exp=1` reports x2 output frames and `interpolation_exp=2` reports x4 output frames.
+
+Useful options:
+
+```bash
+python scripts/run_benchmark.py --config configs/benchmark_config.json --frames 30 --json-output benchmark_report.json
+python scripts/run_benchmark.py --int8 --no-window --output benchmark_report_int8.md
 ```
 
 You can check report generated on my machine in `benchmark_report.txt`

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -1,121 +1,475 @@
 import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import cv2
+import numpy as np
 
 from fluxrt import StreamProcessor
+from fluxrt.utils.benchmark_report import (
+    DEFAULT_DYNAMIC_AREAS,
+    build_benchmark_settings,
+    build_report_summary,
+    interpolation_multiplier,
+    parse_dynamic_areas,
+    render_markdown_report,
+    summarize_case,
+    validate_output_path,
+)
 from fluxrt.utils.scan_hardware import scan_hardware
-import cv2
-import json
-import numpy as np
-import time
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Run FluxRT benchmark.")
-    parser.add_argument("--int8", action="store_true", help="Enable int8 quantization")
-    args = parser.parse_args()
+def make_frame(resolution: dict, dynamic_area: float, frame_index: int) -> np.ndarray:
+    frame = np.zeros((resolution["height"], resolution["width"], 3), dtype=np.uint8)
+    dynamic_width = int(resolution["width"] * dynamic_area)
+    if dynamic_width > 0:
+        frame[:, :dynamic_width, :] = (frame_index * 17) % 255
+    return frame
 
-    config_path = "configs/benchmark_config.json"
 
-    stream_processor = StreamProcessor(config_path)
-    input_tensor = stream_processor.get_input_tensor()
-    output_tensor = stream_processor.get_output_tensor()
-
-    if args.int8:
-        stream_processor.enable_quantization()
-    stream_processor.start()
-
-    resolution = stream_processor.get_resolution()
-
-    print("Initializing...")
+def wait_for_ready(stream_processor: StreamProcessor, timeout: float) -> None:
+    start = time.perf_counter()
     while not stream_processor.is_ready():
-        time.sleep(0.1)
+        failure = get_subprocess_failure(stream_processor)
+        if failure:
+            raise RuntimeError(failure)
+        if time.perf_counter() - start > timeout:
+            raise TimeoutError("startup readiness")
+        time.sleep(0.05)
 
-    print("Warming up...")
-    time.sleep(5)
 
-    results = []
+def wait_for_generated_frame(
+    stream_processor: StreamProcessor, previous_count: int, timeout: float
+) -> dict:
+    start = time.perf_counter()
+    while time.perf_counter() - start <= timeout:
+        failure = get_subprocess_failure(stream_processor)
+        if failure:
+            raise RuntimeError(failure)
+        stats = stream_processor.get_benchmark_stats()
+        generated_frame_count = int(stats.get("generated_frame_count", 0))
+        if generated_frame_count > previous_count:
+            return stats
+        time.sleep(0.005)
+    raise TimeoutError("next generated frame")
 
-    frame = np.zeros((resolution["height"], resolution["width"], 3))
-    aborted = False
-    for dynamic_area in [0.0, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0]:
-        print(f"Testing with dynamic area: {dynamic_area * 100:.0f}%")
-        start = time.time()
-        c = 0
-        sum_processing_time = 0.0
-        sum_fps = 0.0
-        while time.time() - start < 10:
-            c += 1
-            dynamic_width = int(resolution["width"] * dynamic_area)
-            frame[:, 0:dynamic_width, :] = c * 16
-            input_tensor.copy_from(frame)
-            processed_frame = output_tensor.to_numpy()
-            processing_time = stream_processor.get_last_processing_time()
-            fps = 1.0 / processing_time
-            fps *= 2 ** stream_processor.config.get("interpolation_exp", 0)
-            sum_processing_time += processing_time
-            sum_fps += fps
 
-            cv2.imshow("Processed Stream", processed_frame)
-            if cv2.waitKey(1000 // 25) & 0xFF == ord("q"):
-                aborted = True
-                break
-        results.append((dynamic_area, sum_processing_time / c, sum_fps / c))
-        if aborted:
+def wait_for_memory_reset_ack(
+    stream_processor: StreamProcessor, revision: int, timeout: float
+) -> dict:
+    start = time.perf_counter()
+    while time.perf_counter() - start <= timeout:
+        failure = get_subprocess_failure(stream_processor)
+        if failure:
+            raise RuntimeError(failure)
+        stats = stream_processor.get_benchmark_stats()
+        ack = int(stats.get("benchmark_memory_reset_revision", 0))
+        if ack >= revision:
+            return stats
+        time.sleep(0.005)
+    raise TimeoutError("memory reset acknowledgement")
+
+
+def get_subprocess_failure(stream_processor: StreamProcessor) -> str | None:
+    subprocesses = {
+        "model_inference": stream_processor.model_inference_subprocess,
+        "output_scheduler": stream_processor.output_scheduler_subprocess,
+    }
+    for name, subprocess in subprocesses.items():
+        process = getattr(subprocess, "process", None)
+        if process is None or process.pid is None:
+            continue
+        if process.exitcode is not None:
+            return f"{name} subprocess exited with code {process.exitcode}"
+    return None
+
+
+def show_output_frame(output_tensor) -> bool:
+    processed_frame = output_tensor.to_numpy()
+    cv2.imshow("Processed Stream", processed_frame)
+    return bool(cv2.waitKey(1) & 0xFF == ord("q"))
+
+
+def run_generated_frame(
+    stream_processor: StreamProcessor,
+    input_tensor,
+    output_tensor,
+    resolution: dict,
+    dynamic_area: float,
+    frame_index: int,
+    previous_count: int,
+    timeout: float,
+    show_window: bool,
+) -> tuple[dict, bool]:
+    input_tensor.copy_from(make_frame(resolution, dynamic_area, frame_index))
+    stats = wait_for_generated_frame(stream_processor, previous_count, timeout)
+    user_quit = show_output_frame(output_tensor) if show_window else False
+    return stats, user_quit
+
+
+def run_case(
+    stream_processor: StreamProcessor,
+    input_tensor,
+    output_tensor,
+    resolution: dict,
+    dynamic_area: float,
+    warmup_frames: int,
+    frames: int | None,
+    case_duration: float | None,
+    timeout: float,
+    show_window: bool,
+    memory_reset_revision: int,
+    multiplier: int,
+) -> tuple[dict | None, int, str | None]:
+    previous_count = int(
+        stream_processor.get_benchmark_stats().get("generated_frame_count", 0)
+    )
+
+    for frame_index in range(warmup_frames):
+        stats, user_quit = run_generated_frame(
+            stream_processor,
+            input_tensor,
+            output_tensor,
+            resolution,
+            dynamic_area,
+            frame_index,
+            previous_count,
+            timeout,
+            show_window,
+        )
+        previous_count = int(stats.get("generated_frame_count", previous_count))
+        if user_quit:
+            return None, memory_reset_revision, "user_quit"
+
+    memory_reset_revision += 1
+    stream_processor.reset_benchmark_memory_stats(memory_reset_revision)
+    wait_for_memory_reset_ack(stream_processor, memory_reset_revision, timeout)
+
+    previous_count = int(
+        stream_processor.get_benchmark_stats().get("generated_frame_count", 0)
+    )
+    processing_times = []
+    last_stats = stream_processor.get_benchmark_stats()
+    measurement_mode = "duration" if case_duration is not None else "frames"
+    start = time.perf_counter()
+    observed_samples = 0
+    generated_frames = 0
+
+    while True:
+        if frames is not None and generated_frames >= frames:
             break
+        if case_duration is not None and observed_samples > 0:
+            if time.perf_counter() - start >= case_duration:
+                break
 
-    print("Measuring end to end latency...")
+        stats, user_quit = run_generated_frame(
+            stream_processor,
+            input_tensor,
+            output_tensor,
+            resolution,
+            dynamic_area,
+            warmup_frames + observed_samples,
+            previous_count,
+            timeout,
+            show_window,
+        )
+        current_count = int(stats.get("generated_frame_count", previous_count))
+        generated_frames += current_count - previous_count
+        previous_count = current_count
+        last_stats = stats
+        processing_time = float(stats.get("last_processing_time", 0.0) or 0.0)
+        if processing_time > 0:
+            processing_times.append(processing_time)
+        observed_samples += 1
+        if user_quit:
+            elapsed = time.perf_counter() - start
+            case = summarize_case(
+                dynamic_area,
+                processing_times,
+                elapsed,
+                multiplier,
+                last_stats.get("cuda_memory"),
+                measurement_mode,
+                case_duration,
+                generated_frames,
+                observed_samples,
+            )
+            return case, memory_reset_revision, "user_quit"
 
-    frame = np.zeros((resolution["height"], resolution["width"], 3))
+    elapsed = time.perf_counter() - start
+    case = summarize_case(
+        dynamic_area,
+        processing_times,
+        elapsed,
+        multiplier,
+        last_stats.get("cuda_memory"),
+        measurement_mode,
+        case_duration,
+        generated_frames,
+        observed_samples,
+    )
+    return case, memory_reset_revision, None
+
+
+def measure_legacy_latency(
+    stream_processor: StreamProcessor,
+    input_tensor,
+    output_tensor,
+    resolution: dict,
+    timeout: float,
+    show_window: bool,
+) -> dict:
+    frame = np.zeros((resolution["height"], resolution["width"], 3), dtype=np.uint8)
     frame[:, : resolution["width"] // 2, :] = 255
     input_tensor.copy_from(frame)
     stream_processor.set_prompt("Repeat the image")
+
     for _ in range(100):
         processed_frame = output_tensor.to_numpy()
-        cv2.imshow("Processed Stream", processed_frame)
-        if cv2.waitKey(1000 // 25) & 0xFF == ord("q"):
-            break
+        if show_window:
+            cv2.imshow("Processed Stream", processed_frame)
+            if cv2.waitKey(1) & 0xFF == ord("q"):
+                return {"legacy_end_to_end_latency_s": None, "status": "user_quit"}
+
     frame[:, : resolution["width"] // 2 + 16, :] = 255
-    start = time.time()
+    start = time.perf_counter()
     input_tensor.copy_from(frame)
-    while True:
+    while time.perf_counter() - start <= timeout:
         processed_frame = output_tensor.to_numpy()
         if np.any(processed_frame[:, resolution["width"] // 2 + 4 :, :] > 128):
-            break
-        cv2.imshow("Processed Stream", processed_frame)
-        if cv2.waitKey(1) & 0xFF == ord("q"):
-            break
-    end_to_end_latency = time.time() - start
+            return {
+                "legacy_end_to_end_latency_s": time.perf_counter() - start,
+                "status": "ok",
+            }
+        if show_window:
+            cv2.imshow("Processed Stream", processed_frame)
+            if cv2.waitKey(1) & 0xFF == ord("q"):
+                return {"legacy_end_to_end_latency_s": None, "status": "user_quit"}
 
-    cv2.destroyAllWindows()
-    stream_processor.stop()
+    return {"legacy_end_to_end_latency_s": None, "status": "timeout"}
 
-    print("\n####### Benchmark Report #######\n")
-    print("Configuration:\n")
-    print(json.dumps(stream_processor.config, indent=2, default=str))
 
+def run_git(args: list[str]) -> str | None:
+    repo_root = Path(__file__).resolve().parents[1]
+    try:
+        return subprocess.check_output(
+            ["git", *args],
+            cwd=repo_root,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except Exception:
+        return None
+
+
+def get_source_revision() -> dict:
+    commit = run_git(["rev-parse", "--short", "HEAD"])
+    dirty_output = run_git(["status", "--short", "--untracked-files=no"])
+    return {
+        "git_commit": commit or "unknown",
+        "git_dirty": None if dirty_output is None else bool(dirty_output),
+    }
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the FluxRT benchmark.")
+    parser.add_argument(
+        "--config",
+        default="configs/benchmark_config.json",
+        help="Path to the stream processor config.",
+    )
+    parser.add_argument("--int8", action="store_true", help="Enable int8 quantization.")
+    parser.add_argument(
+        "--no-window",
+        action="store_true",
+        help="Disable the OpenCV preview window. Recommended for shared reports.",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Optional Markdown report path. Parent directory must already exist.",
+    )
+    parser.add_argument(
+        "--json-output",
+        default=None,
+        help="Optional JSON report path. Parent directory must already exist.",
+    )
+    parser.add_argument(
+        "--frames",
+        type=int,
+        default=None,
+        help="Generated frames to measure per dynamic area. Default: 30 unless --case-duration is supplied.",
+    )
+    parser.add_argument(
+        "--case-duration",
+        type=float,
+        default=None,
+        help="Optional duration in seconds to measure each dynamic area.",
+    )
+    parser.add_argument("--warmup-frames", type=int, default=5)
+    parser.add_argument("--dynamic-areas", default=DEFAULT_DYNAMIC_AREAS)
+    parser.add_argument("--timeout", type=float, default=180.0)
+    return parser
+
+
+def main():
+    parser = build_arg_parser()
+    args = parser.parse_args()
+
+    try:
+        dynamic_areas = parse_dynamic_areas(args.dynamic_areas)
+        validate_output_path(args.output, "--output")
+        validate_output_path(args.json_output, "--json-output")
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    if args.frames is not None and args.case_duration is not None:
+        parser.error("--frames and --case-duration are mutually exclusive.")
+    if args.frames is not None and args.frames <= 0:
+        parser.error("--frames must be greater than 0.")
+    if args.case_duration is not None and args.case_duration <= 0:
+        parser.error("--case-duration must be greater than 0.")
+    if args.warmup_frames < 0:
+        parser.error("--warmup-frames must be greater than or equal to 0.")
+    if args.timeout <= 0:
+        parser.error("--timeout must be greater than 0.")
+
+    frames = args.frames
+    if frames is None and args.case_duration is None:
+        frames = 30
+
+    measurement_mode = "duration" if args.case_duration is not None else "frames"
+    show_window = not args.no_window
+    stream_processor = StreamProcessor(args.config)
+    input_tensor = stream_processor.get_input_tensor()
+    output_tensor = stream_processor.get_output_tensor()
     if args.int8:
-        print("\nQuantization: int8 enabled through --int8 flag\n")
+        stream_processor.enable_quantization()
 
-    print("\nHardware Information:\n")
-    hardware_info = scan_hardware()
-    print(json.dumps(hardware_info, indent=2, default=str))
+    settings = build_benchmark_settings(
+        stream_processor.config,
+        args.config,
+        args.int8,
+        dynamic_areas,
+        args.warmup_frames,
+        measurement_mode,
+        frames,
+        args.case_duration,
+        args.timeout,
+        show_window,
+    )
 
-    print("\nResults:\n")
-    col_widths = (14, 20, 10)
-    header = f"{'Dynamic Area':>{col_widths[0]}}  {'Processing Time (s)':>{col_widths[1]}}  {'FPS':>{col_widths[2]}}"
-    separator = "-" * len(header)
-    print(separator)
-    print(header)
-    print(separator)
-    for dynamic_area, processing_time, fps in results:
-        print(
-            f"{dynamic_area * 100:>{col_widths[0]}.0f}%"
-            f"  {processing_time:>{col_widths[1]}.4f}"
-            f"  {fps:>{col_widths[2]}.2f}"
+    status = {
+        "completed": False,
+        "aborted": False,
+        "abort_reason": "none",
+        "cases_completed": 0,
+        "cases_requested": len(dynamic_areas),
+    }
+    startup = {
+        "startup_ready_s": None,
+        "ready_vram": {"available": False},
+    }
+    cases = []
+    legacy_latency = {"legacy_end_to_end_latency_s": None, "status": "not_run"}
+    memory_reset_revision = 0
+
+    try:
+        print("Initializing...")
+        startup_start = time.perf_counter()
+        stream_processor.start()
+        wait_for_ready(stream_processor, args.timeout)
+        startup["startup_ready_s"] = time.perf_counter() - startup_start
+        startup["ready_vram"] = stream_processor.get_benchmark_stats().get(
+            "cuda_memory", {"available": False}
         )
-    print(separator)
 
-    print(f"\nEnd-to-end latency: {end_to_end_latency:.4f} seconds\n")
-    print("###### End of Report ######\n")
+        resolution = stream_processor.get_resolution()
+        multiplier = interpolation_multiplier(stream_processor.config)
+
+        for dynamic_area in dynamic_areas:
+            print(f"Benchmarking dynamic area {dynamic_area * 100:.0f}%...")
+            case, memory_reset_revision, abort_reason = run_case(
+                stream_processor,
+                input_tensor,
+                output_tensor,
+                resolution,
+                dynamic_area,
+                args.warmup_frames,
+                frames,
+                args.case_duration,
+                args.timeout,
+                show_window,
+                memory_reset_revision,
+                multiplier,
+            )
+            if case is not None:
+                cases.append(case)
+                status["cases_completed"] = len(cases)
+                print(
+                    f"  base_fps={case['base_fps']:.2f}, "
+                    f"interpolated_fps={case['interpolated_fps']:.2f}, "
+                    f"avg={case['avg_processing_ms']:.1f} ms"
+                )
+            if abort_reason:
+                status["aborted"] = True
+                status["abort_reason"] = abort_reason
+                break
+
+        if not status["aborted"]:
+            print("Running legacy latency probe...")
+            legacy_latency = measure_legacy_latency(
+                stream_processor,
+                input_tensor,
+                output_tensor,
+                resolution,
+                args.timeout,
+                show_window,
+            )
+            if legacy_latency.get("status") == "user_quit":
+                status["aborted"] = True
+                status["abort_reason"] = "user_quit"
+
+    except TimeoutError as exc:
+        status["aborted"] = True
+        status["abort_reason"] = f"timeout: {exc}"
+    except Exception as exc:
+        status["aborted"] = True
+        status["abort_reason"] = f"error: {type(exc).__name__}: {exc}"
+    finally:
+        if show_window:
+            cv2.destroyAllWindows()
+        stream_processor.stop(timeout=5.0)
+
+    status["completed"] = (
+        not status["aborted"] and status["cases_completed"] == status["cases_requested"]
+    )
+    report = {
+        "status": status,
+        "command": " ".join(sys.argv),
+        "source": get_source_revision(),
+        "settings": settings,
+        "environment": scan_hardware(),
+        "startup": startup,
+        "cases": cases,
+        "summary": build_report_summary(cases),
+        "legacy_latency_probe": legacy_latency,
+    }
+    markdown = render_markdown_report(report)
+    print()
+    print(markdown)
+
+    if args.output:
+        Path(args.output).write_text(markdown + "\n", encoding="utf-8")
+        print(f"Wrote Markdown report to: {args.output}")
+    if args.json_output:
+        Path(args.json_output).write_text(
+            json.dumps(report, indent=2, default=str) + "\n", encoding="utf-8"
+        )
+        print(f"Wrote JSON report to: {args.json_output}")
 
 
 if __name__ == "__main__":

--- a/src/fluxrt/stream_processor/model_inference_subprocess.py
+++ b/src/fluxrt/stream_processor/model_inference_subprocess.py
@@ -257,6 +257,9 @@ class ModelInferenceSubprocess:
             if self.process.is_alive():
                 self.process.terminate()
                 self.process.join()
+        if self.manager is not None:
+            self.manager.shutdown()
+            self.manager = None
 
     def set_param(self, name: str, value) -> None:
         self.command_queue.put(("set_param", (name, value)))

--- a/src/fluxrt/stream_processor/model_inference_subprocess.py
+++ b/src/fluxrt/stream_processor/model_inference_subprocess.py
@@ -44,10 +44,19 @@ class ModelInferenceSubprocess:
         self.pack_is_ready = pack_is_ready
         self.last_processing_time = last_processing_time
 
-        manager = Manager()
-        self.command_queue = manager.Queue()
-        self.shared_state = manager.dict()
+        self.manager = Manager()
+        self.command_queue = self.manager.Queue()
+        self.shared_state = self.manager.dict()
+        self.shared_state["generated_frame_count"] = 0
+        self.shared_state["last_processing_time"] = 0.0
+        self.shared_state["cuda_memory"] = self.get_cuda_memory_stats()
+        self.shared_state["benchmark_memory_reset_revision"] = 0
         self.interpolation_exp = self.config.get("interpolation_exp", 1)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["manager"] = None
+        return state
 
     def enable_quantization(self):
         """
@@ -241,13 +250,19 @@ class ModelInferenceSubprocess:
         self.process = Process(target=self.process_main)
         self.process.start()
 
-    def stop(self):
+    def stop(self, timeout: float | None = None):
         self.running.value = False
-        if self.process:
-            self.process.join()
+        if self.process and self.process.pid is not None:
+            self.process.join(timeout)
+            if self.process.is_alive():
+                self.process.terminate()
+                self.process.join()
 
     def set_param(self, name: str, value) -> None:
         self.command_queue.put(("set_param", (name, value)))
+
+    def reset_benchmark_memory_stats(self, revision: int) -> None:
+        self.command_queue.put(("reset_benchmark_memory_stats", revision))
 
     def set_reference_image(self, image: np.ndarray | None) -> None:
         """
@@ -310,9 +325,29 @@ class ModelInferenceSubprocess:
                         .to(self.update_controller.device)
                     )
                     self.update_controller.set_mask(mask_tensor)
+                elif cmd == "reset_benchmark_memory_stats":
+                    revision = int(payload)
+                    if torch.cuda.is_available():
+                        torch.cuda.synchronize()
+                        torch.cuda.reset_peak_memory_stats()
+                    self.shared_state["cuda_memory"] = self.get_cuda_memory_stats()
+                    self.shared_state["benchmark_memory_reset_revision"] = revision
 
         except Empty:
             pass
+
+    def get_cuda_memory_stats(self) -> dict:
+        if not torch.cuda.is_available():
+            return {"available": False}
+
+        mb = 1024 * 1024
+        return {
+            "available": True,
+            "allocated_mb": torch.cuda.memory_allocated() / mb,
+            "reserved_mb": torch.cuda.memory_reserved() / mb,
+            "peak_allocated_mb": torch.cuda.max_memory_allocated() / mb,
+            "peak_reserved_mb": torch.cuda.max_memory_reserved() / mb,
+        }
 
     def receive_frame(self):
         """
@@ -385,8 +420,13 @@ class ModelInferenceSubprocess:
         processing_time = now - prev_time
 
         self.last_processing_time.value = processing_time
+        self.shared_state["last_processing_time"] = processing_time
+        self.shared_state["cuda_memory"] = self.get_cuda_memory_stats()
         self.send_frames(frames)
         self.pack_is_ready.value = True
+        self.shared_state["generated_frame_count"] = (
+            int(self.shared_state.get("generated_frame_count", 0)) + 1
+        )
 
         if self.logging:
             print(

--- a/src/fluxrt/stream_processor/output_scheduler_subprocess.py
+++ b/src/fluxrt/stream_processor/output_scheduler_subprocess.py
@@ -31,10 +31,13 @@ class OutputSchedulerSubprocess:
         self.process = Process(target=self.process_main)
         self.process.start()
 
-    def stop(self) -> None:
+    def stop(self, timeout: float | None = None) -> None:
         self.running.value = False
-        if self.process:
-            self.process.join()
+        if self.process and self.process.pid is not None:
+            self.process.join(timeout)
+            if self.process.is_alive():
+                self.process.terminate()
+                self.process.join()
 
     def process_init(self) -> None:
         """

--- a/src/fluxrt/stream_processor/stream_processor.py
+++ b/src/fluxrt/stream_processor/stream_processor.py
@@ -65,9 +65,9 @@ class StreamProcessor:
     def get_output_tensor(self) -> SharedTensor:
         return self.output_shared_tensor
 
-    def stop(self) -> None:
-        self.model_inference_subprocess.stop()
-        self.output_scheduler_subprocess.stop()
+    def stop(self, timeout: float | None = None) -> None:
+        self.model_inference_subprocess.stop(timeout)
+        self.output_scheduler_subprocess.stop(timeout)
         self.input_shared_tensor.close_and_unlink()
         self.output_shared_tensor.close_and_unlink()
         self.output_batch_shared_tensor.close_and_unlink()
@@ -116,3 +116,9 @@ class StreamProcessor:
 
     def enable_quantization(self) -> None:
         self.model_inference_subprocess.enable_quantization()
+
+    def get_benchmark_stats(self) -> dict:
+        return dict(self.model_inference_subprocess.shared_state)
+
+    def reset_benchmark_memory_stats(self, revision: int) -> None:
+        self.model_inference_subprocess.reset_benchmark_memory_stats(revision)

--- a/src/fluxrt/utils/benchmark_report.py
+++ b/src/fluxrt/utils/benchmark_report.py
@@ -381,7 +381,7 @@ def render_markdown_report(report: dict) -> str:
             f"- max_peak_reserved_mb: {_format_value(summary.get('max_peak_reserved_mb'))}",
             "",
             "## Legacy Latency Probe",
-            f"- legacy_end_to_end_latency_s: {_format_value(legacy_latency.get('legacy_end_to_end_latency_s'))}",
+            f"- legacy_end_to_end_latency_s: {_format_value(legacy_latency.get('legacy_end_to_end_latency_s'), 4)}",
             f"- status: {_format_value(legacy_latency.get('status'))}",
             "",
         ]

--- a/src/fluxrt/utils/benchmark_report.py
+++ b/src/fluxrt/utils/benchmark_report.py
@@ -1,0 +1,390 @@
+import os
+from pathlib import Path
+
+
+DEFAULT_DYNAMIC_AREAS = "0,0.1,0.25,0.5,0.75,0.9,1.0"
+
+
+def parse_dynamic_areas(value: str) -> list[float]:
+    dynamic_areas = []
+    for raw_item in value.split(","):
+        item = raw_item.strip()
+        if not item:
+            continue
+        try:
+            dynamic_area = float(item)
+        except ValueError as exc:
+            raise ValueError(f"Invalid dynamic area '{item}'.") from exc
+        if dynamic_area < 0.0 or dynamic_area > 1.0:
+            raise ValueError(
+                f"Invalid dynamic area '{item}'. Values must be between 0.0 and 1.0."
+            )
+        dynamic_areas.append(dynamic_area)
+
+    if not dynamic_areas:
+        raise ValueError("At least one dynamic area is required.")
+    return dynamic_areas
+
+
+def validate_output_path(path: str | None, label: str) -> None:
+    if path is None:
+        return
+    output_path = Path(path)
+    if output_path.exists() and output_path.is_dir():
+        raise ValueError(f"{label} points to a directory: {path}")
+    parent = output_path.parent
+    if parent and not parent.exists():
+        raise ValueError(f"{label} parent directory does not exist: {parent}")
+
+
+def interpolation_multiplier(config: dict) -> int:
+    return 2 ** int(config.get("interpolation_exp", 0))
+
+
+def sanitize_path(value) -> str:
+    if value is None or value == "":
+        return "unset"
+    normalized = os.path.normpath(str(value))
+    name = os.path.basename(normalized)
+    return name or str(value)
+
+
+def _resolution_text(config: dict) -> str:
+    resolution = config.get("resolution", {})
+    height = resolution.get("height", "unknown")
+    width = resolution.get("width", "unknown")
+    return f"{height}x{width}"
+
+
+def build_benchmark_settings(
+    config: dict,
+    config_path: str,
+    int8_cli_override: bool,
+    dynamic_areas: list[float],
+    warmup_frames: int,
+    measurement_mode: str,
+    frames: int | None,
+    case_duration: float | None,
+    timeout: float,
+    window_enabled: bool,
+) -> dict:
+    multiplier = interpolation_multiplier(config)
+    return {
+        "config_path": sanitize_path(config_path),
+        "prompt": config.get("default_prompt"),
+        "steps": config.get("default_steps"),
+        "seed": config.get("default_seed"),
+        "resolution": _resolution_text(config),
+        "dynamic_area_order": dynamic_areas,
+        "warmup_frames_per_case": warmup_frames,
+        "measurement_mode": measurement_mode,
+        "measured_frames_per_case": frames if measurement_mode == "frames" else None,
+        "case_duration_s": case_duration if measurement_mode == "duration" else None,
+        "cache_reset_between_cases": False,
+        "timeout_s": timeout,
+        "window_enabled": window_enabled,
+        "interpolation": {
+            "interpolation_exp": config.get("interpolation_exp", 0),
+            "interpolation_multiplier": multiplier,
+        },
+        "runtime_features": {
+            "compile_models": config.get("compile_models"),
+            "enable_spatial_cache": config.get("enable_spatial_cache"),
+            "enable_int8_quantization": config.get("enable_int8_quantization"),
+            "int8_cli_override": int8_cli_override,
+            "use_reference_image": config.get("use_reference_image"),
+            "reference_image_resolution": config.get("reference_image_resolution"),
+            "use_lora": config.get("use_lora", False),
+            "target_fps": config.get("target_fps"),
+        },
+        "paths": {
+            "models_path": sanitize_path(config.get("models_path")),
+            "int8_models_path": sanitize_path(config.get("int8_models_path")),
+            "reference_image_path": sanitize_path(config.get("reference_image_path")),
+            "lora_weights_path": sanitize_path(config.get("lora_weights_path")),
+        },
+    }
+
+
+def percentile(values: list[float], q: float) -> float | None:
+    if not values:
+        return None
+    sorted_values = sorted(values)
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+
+    position = (len(sorted_values) - 1) * q
+    lower_index = int(position)
+    upper_index = min(lower_index + 1, len(sorted_values) - 1)
+    fraction = position - lower_index
+    return sorted_values[lower_index] + (
+        sorted_values[upper_index] - sorted_values[lower_index]
+    ) * fraction
+
+
+def summarize_case(
+    dynamic_area: float,
+    processing_times_s: list[float],
+    elapsed_s: float,
+    multiplier: int,
+    memory_stats: dict | None,
+    measurement_mode: str,
+    case_duration: float | None,
+    generated_frames: int | None = None,
+    observed_samples: int | None = None,
+) -> dict:
+    if generated_frames is None:
+        generated_frames = len(processing_times_s)
+    if observed_samples is None:
+        observed_samples = len(processing_times_s)
+    output_frames = generated_frames * multiplier
+    processing_times_ms = [value * 1000.0 for value in processing_times_s]
+    avg_processing_ms = (
+        sum(processing_times_ms) / len(processing_times_ms)
+        if processing_times_ms
+        else None
+    )
+    base_fps = generated_frames / elapsed_s if elapsed_s > 0 else None
+    interpolated_fps = base_fps * multiplier if base_fps is not None else None
+
+    return {
+        "dynamic_area": dynamic_area,
+        "measurement_mode": measurement_mode,
+        "case_duration_s": case_duration if measurement_mode == "duration" else None,
+        "elapsed_s": elapsed_s,
+        "observed_samples": observed_samples,
+        "generated_frames": generated_frames,
+        "output_frames": output_frames,
+        "counter_gap_frames": max(generated_frames - observed_samples, 0),
+        "avg_processing_ms": avg_processing_ms,
+        "p50_processing_ms": percentile(processing_times_ms, 0.50),
+        "p95_processing_ms": percentile(processing_times_ms, 0.95),
+        "base_fps": base_fps,
+        "interpolated_fps": interpolated_fps,
+        "vram": memory_stats or {"available": False},
+    }
+
+
+def build_report_summary(cases: list[dict]) -> dict:
+    base_values = [
+        case["base_fps"] for case in cases if case.get("base_fps") is not None
+    ]
+    interpolated_values = [
+        case["interpolated_fps"]
+        for case in cases
+        if case.get("interpolated_fps") is not None
+    ]
+    peak_allocated_values = [
+        case.get("vram", {}).get("peak_allocated_mb")
+        for case in cases
+        if case.get("vram", {}).get("peak_allocated_mb") is not None
+    ]
+    peak_reserved_values = [
+        case.get("vram", {}).get("peak_reserved_mb")
+        for case in cases
+        if case.get("vram", {}).get("peak_reserved_mb") is not None
+    ]
+    return {
+        "scenario_average_base_fps": (
+            sum(base_values) / len(base_values) if base_values else None
+        ),
+        "scenario_average_interpolated_fps": (
+            sum(interpolated_values) / len(interpolated_values)
+            if interpolated_values
+            else None
+        ),
+        "max_peak_allocated_mb": (
+            max(peak_allocated_values) if peak_allocated_values else None
+        ),
+        "max_peak_reserved_mb": (
+            max(peak_reserved_values) if peak_reserved_values else None
+        ),
+    }
+
+
+def _format_value(value, digits: int = 2) -> str:
+    if value is None:
+        return "n/a"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value)
+
+
+def _format_percent(value: float) -> str:
+    return f"{value * 100:.0f}%"
+
+
+def _render_key_values(values: dict) -> list[str]:
+    return [f"- {key}: {_format_value(value)}" for key, value in values.items()]
+
+
+def render_markdown_report(report: dict) -> str:
+    settings = report["settings"]
+    source = report.get("source", {})
+    status = report.get("status", {})
+    startup = report.get("startup", {})
+    summary = report.get("summary", {})
+    legacy_latency = report.get("legacy_latency_probe", {})
+    lines = ["# FluxRT Benchmark Report", ""]
+
+    lines.extend(
+        [
+            "## Status",
+            f"- completed: {_format_value(status.get('completed'))}",
+            f"- aborted: {_format_value(status.get('aborted'))}",
+            f"- abort_reason: {_format_value(status.get('abort_reason'))}",
+            f"- cases_completed: {_format_value(status.get('cases_completed'), 0)}",
+            f"- cases_requested: {_format_value(status.get('cases_requested'), 0)}",
+            f"- command: `{report.get('command', 'unknown')}`",
+            f"- git_commit: {_format_value(source.get('git_commit'))}",
+            f"- git_dirty: {_format_value(source.get('git_dirty'))}",
+            "",
+        ]
+    )
+
+    lines.extend(
+        [
+            "## Benchmark Settings",
+            f"- config_path: `{settings['config_path']}`",
+            f"- prompt: {settings.get('prompt')}",
+            f"- steps: {_format_value(settings.get('steps'), 0)}",
+            f"- seed: {_format_value(settings.get('seed'), 0)}",
+            f"- resolution: {settings.get('resolution')}",
+            f"- dynamic_area_order: {settings.get('dynamic_area_order')}",
+            f"- warmup_frames_per_case: {_format_value(settings.get('warmup_frames_per_case'), 0)}",
+            f"- measurement_mode: {settings.get('measurement_mode')}",
+            f"- measured_frames_per_case: {_format_value(settings.get('measured_frames_per_case'), 0)}",
+            f"- case_duration_s: {_format_value(settings.get('case_duration_s'))}",
+            f"- cache_reset_between_cases: {_format_value(settings.get('cache_reset_between_cases'))}",
+            f"- timeout_s: {_format_value(settings.get('timeout_s'))}",
+            f"- window_enabled: {_format_value(settings.get('window_enabled'))}",
+            "",
+            "Runtime features:",
+        ]
+    )
+    lines.extend(_render_key_values(settings["runtime_features"]))
+    lines.extend(["", "Interpolation:"])
+    lines.extend(_render_key_values(settings["interpolation"]))
+    lines.extend(["", "Paths:"])
+    lines.extend(_render_key_values(settings["paths"]))
+    lines.append("")
+
+    lines.extend(["## Benchmark Environment"])
+    environment = report.get("environment", {})
+    software = environment.get("software", {})
+    lines.extend(
+        [
+            f"- platform: {_format_value(environment.get('platform'))}",
+            f"- python: {_format_value(environment.get('python'))}",
+            f"- torch: {_format_value(software.get('torch'))}",
+            f"- torch_cuda: {_format_value(software.get('torch_cuda'))}",
+            f"- cudnn: {_format_value(software.get('cudnn'))}",
+            f"- cpu: {_format_value(environment.get('cpu'))}",
+            f"- cpu_cores_logical: {_format_value(environment.get('cpu_cores_logical'), 0)}",
+            f"- system_ram_gb: {_format_value(environment.get('system_ram_gb'))}",
+            f"- nvidia_driver: {_format_value(environment.get('nvidia_driver'))}",
+        ]
+    )
+    packages = software.get("packages", {})
+    if packages:
+        lines.extend(["", "Packages:"])
+        lines.extend(_render_key_values(packages))
+    gpus = environment.get("gpu")
+    if isinstance(gpus, list):
+        lines.extend(
+            [
+                "",
+                "GPUs:",
+                "",
+                "| Index | Name | VRAM GB | CC | SMs |",
+                "| ---: | --- | ---: | ---: | ---: |",
+            ]
+        )
+        for gpu in gpus:
+            lines.append(
+                "| "
+                f"{_format_value(gpu.get('index'), 0)} | "
+                f"{_format_value(gpu.get('name'))} | "
+                f"{_format_value(gpu.get('vram_gb'))} | "
+                f"{_format_value(gpu.get('cc'))} | "
+                f"{_format_value(gpu.get('multi_processor_count'), 0)} |"
+            )
+    else:
+        lines.extend(["", f"- gpu: {_format_value(gpus)}"])
+    lines.append("")
+
+    ready_vram = startup.get("ready_vram", {})
+    lines.extend(
+        [
+            "## Startup / Ready",
+            f"- startup_ready_s: {_format_value(startup.get('startup_ready_s'))}",
+            f"- ready_allocated_mb: {_format_value(ready_vram.get('allocated_mb'))}",
+            f"- ready_reserved_mb: {_format_value(ready_vram.get('reserved_mb'))}",
+            f"- ready_peak_allocated_mb: {_format_value(ready_vram.get('peak_allocated_mb'))}",
+            f"- ready_peak_reserved_mb: {_format_value(ready_vram.get('peak_reserved_mb'))}",
+            "",
+        ]
+    )
+
+    lines.extend(
+        [
+            "## Throughput",
+            "",
+            "| Dynamic | Observed | Generated | Output | Counter Gap | Avg ms | P50 ms | P95 ms | Base FPS | Interpolated FPS |",
+            "| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for case in report.get("cases", []):
+        lines.append(
+            "| "
+            f"{_format_percent(case['dynamic_area'])} | "
+            f"{case.get('observed_samples', case['generated_frames'])} | "
+            f"{case['generated_frames']} | "
+            f"{case['output_frames']} | "
+            f"{case.get('counter_gap_frames', 0)} | "
+            f"{_format_value(case.get('avg_processing_ms'))} | "
+            f"{_format_value(case.get('p50_processing_ms'))} | "
+            f"{_format_value(case.get('p95_processing_ms'))} | "
+            f"{_format_value(case.get('base_fps'))} | "
+            f"{_format_value(case.get('interpolated_fps'))} |"
+        )
+    lines.append("")
+
+    lines.extend(
+        [
+            "## VRAM",
+            "",
+            "| Dynamic | Alloc MB | Reserved MB | Peak Alloc MB | Peak Reserved MB |",
+            "| ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for case in report.get("cases", []):
+        vram = case.get("vram", {})
+        lines.append(
+            "| "
+            f"{_format_percent(case['dynamic_area'])} | "
+            f"{_format_value(vram.get('allocated_mb'))} | "
+            f"{_format_value(vram.get('reserved_mb'))} | "
+            f"{_format_value(vram.get('peak_allocated_mb'))} | "
+            f"{_format_value(vram.get('peak_reserved_mb'))} |"
+        )
+    lines.append("")
+
+    lines.extend(
+        [
+            "## Summary",
+            f"- scenario_average_base_fps: {_format_value(summary.get('scenario_average_base_fps'))}",
+            f"- scenario_average_interpolated_fps: {_format_value(summary.get('scenario_average_interpolated_fps'))}",
+            f"- max_peak_allocated_mb: {_format_value(summary.get('max_peak_allocated_mb'))}",
+            f"- max_peak_reserved_mb: {_format_value(summary.get('max_peak_reserved_mb'))}",
+            "",
+            "## Legacy Latency Probe",
+            f"- legacy_end_to_end_latency_s: {_format_value(legacy_latency.get('legacy_end_to_end_latency_s'))}",
+            f"- status: {_format_value(legacy_latency.get('status'))}",
+            "",
+        ]
+    )
+
+    return "\n".join(lines)

--- a/src/fluxrt/utils/scan_hardware.py
+++ b/src/fluxrt/utils/scan_hardware.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import subprocess
+from importlib import metadata
 import torch
 
 
@@ -17,7 +18,12 @@ def get_cpu_name():
     system = platform.system()
 
     if system == "Windows":
-        return _run(["wmic", "cpu", "get", "name"]).splitlines()[1].strip()
+        output = _run(["wmic", "cpu", "get", "name"])
+        if output:
+            lines = [line.strip() for line in output.splitlines() if line.strip()]
+            if len(lines) > 1:
+                return lines[1]
+        return platform.processor() or "Unknown CPU"
 
     if system == "Darwin":
         return _run(["sysctl", "-n", "machdep.cpu.brand_string"])
@@ -45,21 +51,109 @@ def get_gpu_info():
 
         gpus.append(
             {
+                "index": i,
                 "name": props.name,
                 "vram_gb": round(props.total_memory / 1024**3, 2),
+                "vram_mb": round(props.total_memory / 1024**2, 2),
                 "cc": f"{props.major}.{props.minor}",
+                "multi_processor_count": props.multi_processor_count,
             }
         )
 
     return gpus
 
 
+def get_system_ram_gb():
+    system = platform.system()
+
+    if system == "Windows":
+        try:
+            import ctypes
+
+            class MemoryStatus(ctypes.Structure):
+                _fields_ = [
+                    ("dwLength", ctypes.c_ulong),
+                    ("dwMemoryLoad", ctypes.c_ulong),
+                    ("ullTotalPhys", ctypes.c_ulonglong),
+                    ("ullAvailPhys", ctypes.c_ulonglong),
+                    ("ullTotalPageFile", ctypes.c_ulonglong),
+                    ("ullAvailPageFile", ctypes.c_ulonglong),
+                    ("ullTotalVirtual", ctypes.c_ulonglong),
+                    ("ullAvailVirtual", ctypes.c_ulonglong),
+                    ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+                ]
+
+            status = MemoryStatus()
+            status.dwLength = ctypes.sizeof(MemoryStatus)
+            if ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(status)):
+                return round(status.ullTotalPhys / 1024**3, 2)
+        except Exception:
+            return None
+
+    if system == "Darwin":
+        output = _run(["sysctl", "-n", "hw.memsize"])
+        if output:
+            try:
+                return round(int(output) / 1024**3, 2)
+            except ValueError:
+                pass
+
+    if hasattr(os, "sysconf"):
+        try:
+            pages = os.sysconf("SC_PHYS_PAGES")
+            page_size = os.sysconf("SC_PAGE_SIZE")
+            return round(pages * page_size / 1024**3, 2)
+        except (ValueError, OSError):
+            pass
+
+    return None
+
+
+def get_nvidia_driver_version():
+    output = _run(
+        ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"]
+    )
+    if not output:
+        return None
+    return output.splitlines()[0].strip()
+
+
+def get_package_version(package_name):
+    try:
+        return metadata.version(package_name)
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def get_software_versions():
+    packages = [
+        "torch",
+        "torchvision",
+        "diffusers",
+        "transformers",
+        "accelerate",
+        "optimum-quanto",
+        "peft",
+        "numpy",
+        "opencv-python",
+    ]
+    return {
+        "torch": torch.__version__,
+        "torch_cuda": torch.version.cuda,
+        "cudnn": torch.backends.cudnn.version(),
+        "packages": {name: get_package_version(name) for name in packages},
+    }
+
+
 def scan_hardware():
     info = {
         "platform": platform.platform(),
         "python": platform.python_version(),
+        "software": get_software_versions(),
         "cpu": get_cpu_name(),
         "cpu_cores_logical": os.cpu_count(),
+        "system_ram_gb": get_system_ram_gb(),
+        "nvidia_driver": get_nvidia_driver_version(),
         "gpu": get_gpu_info(),
     }
     return info


### PR DESCRIPTION
## Summary

This PR adds a unified benchmark report generator for FluxRT's existing synthetic dynamic-area workload.

It focuses on the benchmark/reporting gaps discussed in #12:

- reports VRAM from the inference subprocess
- separates base FPS from interpolated FPS
- reports generated/output frame counts and the interpolation multiplier
- emits a Markdown report to stdout and optionally writes Markdown/JSON files
- preserves the existing legacy latency probe in a separate section

This intentionally does not add 4-bit quantization, TensorRT, a profiler, a cache-reset benchmark mode, or a pipeline refactor.

## What changed

- Reworked `scripts/run_benchmark.py` around explicit CLI options:
  - `--config`
  - `--int8`
  - `--no-window`
  - `--output`
  - `--json-output`
  - `--frames`
  - `--case-duration`
  - `--warmup-frames`
  - `--dynamic-areas`
  - `--timeout`
- Added `src/fluxrt/utils/benchmark_report.py` for report data shaping and Markdown rendering.
- Added minimal runtime observability in `ModelInferenceSubprocess`:
  - monotonic `generated_frame_count`
  - CUDA allocated/reserved/peak VRAM stats
  - benchmark peak-memory reset with revision acknowledgement
- Added `StreamProcessor.get_benchmark_stats()` and `reset_benchmark_memory_stats()` for the benchmark runner.
- Expanded hardware/environment reporting with CPU/RAM/GPU, driver, Python, Torch/CUDA/cuDNN, and key package versions.
- Updated the README benchmark section with the recommended `--no-window --output` usage.

## Methodology

The benchmark continues to use the existing synthetic `dynamic_area` workload as the comparison axis.

For each dynamic area:

1. Warmup frames are run first to absorb the transition after changing the input pattern.
2. CUDA peak-memory stats are reset after warmup and acknowledged by the inference subprocess.
3. Measured frames are counted from the inference subprocess' monotonic generated-frame counter.
4. Base FPS is computed from generated frames before interpolation.
5. Interpolated FPS applies the configured `2 ** interpolation_exp` multiplier.

The report explicitly includes:

- `warmup_frames_per_case`
- `dynamic_area_order`
- `cache_reset_between_cases: false`
- `interpolation_exp`
- `interpolation_multiplier`
- generated frames and output frames
- allocated/reserved/peak VRAM per case

The benchmark measures steady-state streaming throughput for the selected config. Prompt-change latency and reference-image swap latency are out of scope for this PR; related settings remain reported as config metadata.

## Validation

Ran locally in a Python 3.12 conda environment with an RTX 3090:

```bash
git diff --cached --check
conda run -n fluxrt python -m py_compile scripts/run_benchmark.py src/fluxrt/stream_processor/model_inference_subprocess.py src/fluxrt/stream_processor/output_scheduler_subprocess.py src/fluxrt/stream_processor/stream_processor.py src/fluxrt/utils/scan_hardware.py src/fluxrt/utils/benchmark_report.py
conda run -n fluxrt python scripts/run_benchmark.py --help
```

Also ran a real smoke benchmark with local model weights, `compile_models=false`, `default_steps=1`, one dynamic area, and one measured frame:

```bash
conda run -n fluxrt python scripts/run_benchmark.py --config <temp_config> --no-window --frames 1 --warmup-frames 0 --dynamic-areas 0 --timeout 900 --output <temp_md> --json-output <temp_json>
```

Result: completed successfully and produced Markdown/JSON reports with base FPS, interpolated FPS, frame counts, startup VRAM, and per-case peak VRAM.

Local note: running the repository's default `compile_models=true` config on Windows failed in TorchInductor because Triton was unavailable. The benchmark now reports that as an aborted partial report instead of hanging.
