### PR TITLE
Input connect/reconnect: single owner, seamless handoff (bounded dead-owner freeze)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Shell scripts must use LF so they run on Linux servers (CRLF breaks the shebang).
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,11 @@ docs/_build/
 # PyBuilder
 .pybuilder/
 target/
-output/
+
+# Script run artifacts (e.g. run_face_reenactment.py --output-dir). Anchored to
+# repo root with a leading slash: an unanchored `output/` matches a dir of that
+# name at ANY depth and silently swallowed scripts/client/src/components/output/.
+/output/
 
 # Jupyter Notebook
 .ipynb_checkpoints
@@ -221,3 +225,11 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Per-machine generated / runtime-local files (untracked to avoid pull conflicts)
+scripts/saved_prompts.json
+# ComfyUI workflow exports — locally re-exported per machine (see /comfy/edit)
+scripts/comfy_workflows/*.json
+
+# npm lockfiles — this project uses yarn only; ignore any stray npm output
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ Example 2: interactive paint-style app with iterative image updates.
 
 Ensure you have **git**, **git lfs** and **conda** installed.
 
-CUDA **12.8** is recommended. 
+**Python 3.12** is required — the package pins `requires-python >= 3.12`, so Python 3.11 and earlier are rejected by `pip install -e .`.
+
+CUDA **12.8** is recommended. The same `cu128` PyTorch wheels cover both the **RTX 4090** (Ada, `sm_89`) and the **RTX 5090** (Blackwell, `sm_120`), so a single install works for either card. 
 
 ## Windows
 
@@ -77,6 +79,8 @@ sh scripts/install.sh
 ```
 
 GUI reqires **v4l2loopback** to be installed and loaded to access virtual webcam. 
+
+Both `install.bat` and `install.sh` set up the environment (Python 3.12 + CUDA 12.8 PyTorch) and download **all five models** automatically — RIFE, FLUX.2-klein-4B, the int8 quant, TAEF2 and Flow Upscaler. The per-model `git clone` commands under [Manual Installation](#manual-installation) and [Extensions](#extensions) are only needed if you set things up by hand. The scripts are idempotent, so re-running them only fetches what is missing.
 
 # Manual Installation
 
@@ -119,11 +123,40 @@ uv pip install -r requirements.txt
 uv pip install -e .
 ```
 
-**Windows note**: `triton-windows` is required for model compilation. It would be installed automatically on windows, but if you have some issues check [triton-windows compatibility](https://github.com/woct0rdho/triton-windows/issues/158).
+**Windows note**: `triton-windows` is required for model compilation. It would be installed automatically on windows, but if you have some issues check [triton-windows compatibility](https://github.com/woct0rdho/triton-windows/issues/158). On Linux, Triton ships with the PyTorch wheel — nothing extra to install.
+
+### Verify the GPU is detected
+
+Run this inside the environment before downloading models:
+
+```bash
+python -c "import torch; print(torch.cuda.get_arch_list(), torch.cuda.is_available(), torch.cuda.get_device_name(0))"
+```
+
+The arch list should contain `sm_89` (RTX 4090) or `sm_120` (RTX 5090), and CUDA should report `True`. If your card is missing, you likely have a CPU-only or pre-`cu128` build — reinstall with the `--upgrade` flag and the `cu128` index URL above:
+
+```bash
+pip install --upgrade torch torchvision --index-url https://download.pytorch.org/whl/cu128
+```
+
+### Optional: WebRTC browser streaming
+
+To stream the output to any browser on the LAN (`scripts/run_webrtc.py`), install the extra dependencies into the **same** environment:
+
+```bash
+pip install -r requirements_webrtc.txt          # conda
+uv pip install -r requirements_webrtc.txt       # uv
+```
+
+(On Windows, `uvloop` from the `uvicorn[standard]` extra is skipped automatically — that is expected, not an error.)
 
 ## 3. Download Models
 
-Ensure you have git lfs installed or run `git lfs install`
+Ensure you have git lfs installed or run `git lfs install`.
+
+All model paths used by the code are **relative to the repository root**, so clone every model into `FluxRT/` and launch the app from there. Two models are **always required** — **RIFE** and **FLUX.2-klein-4B**; the rest are optional [extensions](#extensions).
+
+After each clone, confirm Git LFS actually pulled the weights: the `.safetensors` files should be hundreds of MB, not ~130-byte pointer files. If a file is still a pointer, run `git -C <model-dir> lfs pull`. A missing or pointer-only file shows up at startup as `FileNotFoundError: No such file or directory: <model>/<file>.safetensors`.
 
 ### RIFE Frame Interpolation Model
 
@@ -211,7 +244,20 @@ cd FluxRT
 git clone https://huggingface.co/aydin99/FLUX.2-klein-4B-int8
 ```
 
-Note that downloading unquantized `FLUX.2-klein-4B` model is **still reqired**.
+Note that downloading the unquantized `FLUX.2-klein-4B` model is **still required** — it provides the VAE and scheduler config even in int8 mode.
+
+#### Usage
+
+Set in config:
+```json
+"enable_int8_quantization": true
+```
+or pass `--int8` to `scripts/run_webrtc.py`.
+
+#### Which to use
+
+- **RTX 5090 (32 GB)** — run the full unquantized model (`enable_int8_quantization: false`); you have the VRAM headroom for it and can also enable TAEF2 + Flow Upscaler.
+- **RTX 4090 (24 GB)** — enable int8 (minimum 20 GB). The full bf16 model may run out of memory; TAEF2 further reduces decoder VRAM.
 
 
 #### Usage

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Example 2: interactive paint-style app with iterative image updates.
 
 # Quick Start
 
-Ensure you have **git**, **git lfs** and **conda** installed.
+Ensure you have **git**, **git lfs** and **[uv](https://docs.astral.sh/uv/)** installed.
 
-**Python 3.12** is required — the package pins `requires-python >= 3.12`, so Python 3.11 and earlier are rejected by `pip install -e .`.
+**Python 3.12** is required — the package pins `requires-python >= 3.12`, so Python 3.11 and earlier are rejected by `uv pip install -e .`.
 
 CUDA **12.8** is recommended. The same `cu128` PyTorch wheels cover both the **RTX 4090** (Ada, `sm_89`) and the **RTX 5090** (Blackwell, `sm_120`), so a single install works for either card. 
 
@@ -93,29 +93,17 @@ cd FluxRT
 
 ## 2. Install Dependencies
 
-### Option A: conda
+FluxRT uses [uv](https://docs.astral.sh/uv/) for environment and dependency management.
 
 ```bash
-# Create environment
-conda create -n fluxrt python=3.12 pip -y
-conda activate fluxrt
-
-# Install PyTorch with CUDA support (adjust if needed)
-pip install torch torchvision --index-url https://download.pytorch.org/whl/cu128
-
-# Install project dependencies
-pip install -r requirements.txt
-pip install -e .
-```
-
-### Option B: uv
-
-```bash
-# Install uv if you don't have it
-pip install uv
-
-# Create environment and install PyTorch with CUDA support
+# Create the virtual environment (uv fetches Python 3.12 if needed)
 uv venv --python 3.12
+
+# Activate it
+source .venv/bin/activate        # Linux / macOS
+.venv\Scripts\activate           # Windows
+
+# Install PyTorch with CUDA 12.8 (covers RTX 4090 sm_89 and RTX 5090 sm_120)
 uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu128
 
 # Install project dependencies
@@ -136,7 +124,7 @@ python -c "import torch; print(torch.cuda.get_arch_list(), torch.cuda.is_availab
 The arch list should contain `sm_89` (RTX 4090) or `sm_120` (RTX 5090), and CUDA should report `True`. If your card is missing, you likely have a CPU-only or pre-`cu128` build — reinstall with the `--upgrade` flag and the `cu128` index URL above:
 
 ```bash
-pip install --upgrade torch torchvision --index-url https://download.pytorch.org/whl/cu128
+uv pip install --upgrade torch torchvision --index-url https://download.pytorch.org/whl/cu128
 ```
 
 ### Optional: WebRTC browser streaming
@@ -144,8 +132,7 @@ pip install --upgrade torch torchvision --index-url https://download.pytorch.org
 To stream the output to any browser on the LAN (`scripts/run_webrtc.py`), install the extra dependencies into the **same** environment:
 
 ```bash
-pip install -r requirements_webrtc.txt          # conda
-uv pip install -r requirements_webrtc.txt       # uv
+uv pip install -r requirements_webrtc.txt
 ```
 
 (On Windows, `uvloop` from the `uvicorn[standard]` extra is skipped automatically — that is expected, not an error.)
@@ -259,16 +246,6 @@ or pass `--int8` to `scripts/run_webrtc.py`.
 - **RTX 5090 (32 GB)** — run the full unquantized model (`enable_int8_quantization: false`); you have the VRAM headroom for it and can also enable TAEF2 + Flow Upscaler.
 - **RTX 4090 (24 GB)** — enable int8 (minimum 20 GB). The full bf16 model may run out of memory; TAEF2 further reduces decoder VRAM.
 
-
-#### Usage
-
-Set in config:
-```json
-"enable_int8_quantization": true
-```
-
-Or use `--int8` flag when running scripts.
-
 ### Style customization: LoRA
 
 #### Installation
@@ -293,7 +270,7 @@ Real-time face reenactment that transfers facial expressions from the webcam fee
 
 ```bash
 git clone https://github.com/KlingAIResearch/LivePortrait LivePortrait-code
-pip install -r requirements_lipsync.txt
+uv pip install -r requirements_lipsync.txt
 git clone https://huggingface.co/KwaiVGI/LivePortrait
 ```
 
@@ -347,10 +324,11 @@ The GUI toggle button will be enabled automatically when this is present in the 
 
 # Running scripts
 
-Run any script with conda environment activated:
+Run any script with the virtual environment activated:
 
 ```bash
-conda activate fluxrt
+source .venv/bin/activate        # Linux / macOS
+.venv\Scripts\activate           # Windows
 ```
 
 ### GUI and Virtual Web Camera
@@ -427,7 +405,7 @@ Includes a minimal HTML/JS client served at `/`, with a prompt control channel.
 Install the WebRTC extras once:
 
 ```bash
-pip install -r requirements_webrtc.txt
+uv pip install -r requirements_webrtc.txt
 ```
 
 Then start the server:

--- a/README.md
+++ b/README.md
@@ -373,6 +373,34 @@ This script also supports CLI
 python scripts/process_local_video.py --input input.mp4 --output out.mp4 --prompt "Turn this into oil on canvas art"
 ```
 
+### WebRTC Browser Streaming
+
+Streams the FluxRT output over WebRTC to any modern browser on the LAN.
+Includes a minimal HTML/JS client served at `/`, with a prompt control channel.
+
+Install the WebRTC extras once:
+
+```bash
+pip install -r requirements_webrtc.txt
+```
+
+Then start the server:
+
+```bash
+python scripts/run_webrtc.py
+```
+
+Optional flags:
+* `--int8` — enable int8 quantization
+* `--config` — pick a different config file
+* `--port` — change the listening port (default `8765`)
+* `--camera` — choose the OpenCV camera index
+* `--initial-prompt` — set a prompt before the first client connects
+
+Open `http://<server-lan-ip>:8765/` on any LAN browser, click **Start**, and
+type prompts directly in the page. Glass-to-glass latency on a LAN is typically
+under 200 ms.
+
 ### Run Performance Benchmark
 
 This will show throughput (FPS) with various dynamic area values, end-to-end latency and reserved GPU memory.

--- a/SPEC.md
+++ b/SPEC.md
@@ -30,12 +30,13 @@ R4|browser side|'disconnected' transient, may self-heal; escalation to 'failed' 
 ## §V INVARIANTS
 V1: ∀ time ≤1 owner (existing machine + tests)
 V2: owner w/ 0 other waiters ⊥ gap-evicted — holds slot until terminal state / consent expiry backstop
-V3: owner silent ≥ OWNER_GAP_WITH_WAITER & ≥1 other waiter → released; oldest waiter claims on its next frame
+V3: owner silent ≥ OWNER_GAP_WITH_WAITER & ≥1 other waiter → released ≤ threshold+poll(1s)+claim(≤1s) ≈ 10s worst; oldest waiter claims on its next frame
 V4: handoff msgs: `input:you` → new owner only; `input:peer` broadcast (existing _input_notify path)
 V5: waiter first-frame policy unchanged (WAITER_FIRST_FRAME_DEADLINE 25s, connected-waiter never evicted)
 V6: client engine: 'disconnected' recovers ≤3s → same pc kept, ⊥ renegotiation; expires → teardown+retry w/ backoff; `closed=true` halts all retry
 V7: client engine: inbound ctrl decoded; unknown msg → ignored, ⊥ throw; inputRole surfaced per clip
 V8: `webrtc_test_client.html` connects & functions unmodified
+V9: gap-yielded peer (pc alive) ! keep draining its track (aiortc decodes inbound RTP → unbounded queue) & rejoins as newest waiter ∴ can reclaim when slot frees; ⊥ alive undrained track
 
 ## §T TASKS
 id|status|task|cites
@@ -50,3 +51,4 @@ T8|x|client vitest: grace cancel/expiry/closed-halt; ctrl dispatch (fake RTCPeer
 
 ## §B BUGS
 id|date|cause|fix
+B1|2026-07-06|gap-yield `return`ed w/ pc alive → nobody drains track; aiortc decodes regardless → queue grows ~12MB/s if paused cam resumes (caught in review, pre-merge)|V9

--- a/SPEC.md
+++ b/SPEC.md
@@ -44,9 +44,9 @@ T2|x|`InputOwnership.num_other_waiters(pc)` under lock|V3,C1
 T3|x|`_pump_owner_frames`: gap supervision → policy fire → return (release via existing finally)|V3,C2
 T4|x|server tests: gap+waiter evicts & handoff; gap no-waiter holds; frame-delivering owner + waiter never evicted|V2,V3,V5
 T5|x|`run_webrtc.py` comment fix re aiortc states (no behavior change)|R2
-T6|.|`engineSession.ts`: 3s disconnected-grace + connectionstatechange 'failed' → retry|V6
-T7|.|`engineSession.ts`: `ch.onmessage` → decodeCtrl → per-clip role|V7,C4
-T8|.|client vitest: grace cancel/expiry/closed-halt; ctrl dispatch (fake RTCPeerConnection + fake timers)|V6,V7
+T6|x|`engineSession.ts`: 3s disconnected-grace + connectionstatechange 'failed' → retry|V6
+T7|x|`engineSession.ts`: `ch.onmessage` → decodeCtrl → per-clip role|V7,C4
+T8|x|client vitest: grace cancel/expiry/closed-halt; ctrl dispatch (fake RTCPeerConnection + fake timers)|V6,V7
 
 ## §B BUGS
 id|date|cause|fix

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,52 @@
+# SPEC — input connect/reconnect: single owner, seamless handoff
+
+## §G GOAL
+∀ time ≤1 peer drives pipeline input; owner death/leave → oldest waiter takes over seamless (≤~9s worst case, next-frame when graceful); transient blip ⊥ force full renegotiation (client grace); no-waiter owner ⊥ evicted on gap.
+
+## §C CONSTRAINTS
+- C1: InputOwnership sole mutator of owner/waiter/active state; policy fns pure, unit-testable w/o aiortc/GPU (existing module ethos).
+- C2: c855950 guard FROZEN: ⊥ blind gap-evict owner. Gap-evict ONLY w/ takeover candidate present (§R1).
+- C3: aiortc connectionState ∈ {new,connecting,connected,failed,closed}; ⊥ 'disconnected' server-side (§R2). Server logic ⊥ depend on 'disconnected' firing.
+- C4: wire protocol `ctrlProtocol.ts` frozen — no new msg types (frame-gap needs none).
+- C5: client scope = `engineSession.ts` only; `sessionStore.ts` untouched.
+- C6: existing backoff `min(800·1.7^n, 6000)` & `waitServerReady` gating stay.
+- C7: old test client `scripts/webrtc_test_client.html` ! keep working unmodified.
+
+## §I INTERFACES
+- fn: `owner_gap_should_release(gap_s: float, other_waiters: int) -> bool`  // pure, input_ownership.py; True iff gap_s ≥ OWNER_GAP_WITH_WAITER & other_waiters ≥ 1
+- const: `OWNER_GAP_WITH_WAITER = 8.0`  // input_ownership.py
+- method: `InputOwnership.num_other_waiters(pc) -> int`  // waiters excl. pc's own seq, under lock
+- behavior: `_pump_owner_frames` gains gap supervision (recv wrapped in wait_for vs last-frame ts; claim time = initial ts) → policy fire → pump returns → existing `finally: release()` handoff path
+- client: `engineSession.ts` — ice 'disconnected' → 3s grace timer → `scheduleRetry`; 'connected|completed' cancels; `pc.onconnectionstatechange === 'failed'` → `scheduleRetry`; `ch.onmessage` → `decodeCtrl` → per-clip inputRole via onStatus/store
+- api: `/healthz` unchanged (`input_waiters`, `input_source` already exposed — e2e observability)
+
+## §R RESEARCH
+id|topic|finding|src
+R1|prior regression|c855950 blind 5s owner gap-evict froze healthy owners (keyframe/TURN settle, paused cam) → fixed by never-gap-evict; new policy conditions evict on waiter presence, not gap alone|FluxRT git history + input_ownership.py docstring
+R2|aiortc states|connectionState ⊥ 'disconnected' — explicit `# NOTE: we do not have a 'disconnected' state`; states new/connecting/connected/failed/closed|github.com/aiortc/aiortc rtcpeerconnection.py __updateConnectionState
+R3|dead-peer latency|aioice RFC7675 consent: CONSENT_INTERVAL=5, CONSENT_FAILURES=6, interval ×(0.8–1.2) → dead peer → close ≈25–35s|github.com/aiortc/aioice ice.py query_consent
+R4|browser side|'disconnected' transient, may self-heal; escalation to 'failed' browser-dependent (~10s); engineSession.ts:136 comment relies on it|MDN RTCPeerConnection.connectionState
+
+## §V INVARIANTS
+V1: ∀ time ≤1 owner (existing machine + tests)
+V2: owner w/ 0 other waiters ⊥ gap-evicted — holds slot until terminal state / consent expiry backstop
+V3: owner silent ≥ OWNER_GAP_WITH_WAITER & ≥1 other waiter → released; oldest waiter claims on its next frame
+V4: handoff msgs: `input:you` → new owner only; `input:peer` broadcast (existing _input_notify path)
+V5: waiter first-frame policy unchanged (WAITER_FIRST_FRAME_DEADLINE 25s, connected-waiter never evicted)
+V6: client engine: 'disconnected' recovers ≤3s → same pc kept, ⊥ renegotiation; expires → teardown+retry w/ backoff; `closed=true` halts all retry
+V7: client engine: inbound ctrl decoded; unknown msg → ignored, ⊥ throw; inputRole surfaced per clip
+V8: `webrtc_test_client.html` connects & functions unmodified
+
+## §T TASKS
+id|status|task|cites
+T1|x|`input_ownership.py`: add OWNER_GAP_WITH_WAITER + pure `owner_gap_should_release`|V2,V3
+T2|x|`InputOwnership.num_other_waiters(pc)` under lock|V3,C1
+T3|x|`_pump_owner_frames`: gap supervision → policy fire → return (release via existing finally)|V3,C2
+T4|x|server tests: gap+waiter evicts & handoff; gap no-waiter holds; frame-delivering owner + waiter never evicted|V2,V3,V5
+T5|x|`run_webrtc.py` comment fix re aiortc states (no behavior change)|R2
+T6|.|`engineSession.ts`: 3s disconnected-grace + connectionstatechange 'failed' → retry|V6
+T7|.|`engineSession.ts`: `ch.onmessage` → decodeCtrl → per-clip role|V7,C4
+T8|.|client vitest: grace cancel/expiry/closed-halt; ctrl dispatch (fake RTCPeerConnection + fake timers)|V6,V7
+
+## §B BUGS
+id|date|cause|fix

--- a/configs/config_with_reference.json
+++ b/configs/config_with_reference.json
@@ -1,5 +1,5 @@
 {
-    "default_prompt" : "Make professional soft light: cyberpunk gaming room, red and violet light, soft streamer's light, warm white light, cinematic, beautiful, professional, bokeh",
+    "default_prompt" : "person with giant googly eyes",
     "default_steps" : 2,
     "default_seed" : 52,
     "models_path" : "FLUX.2-klein-4B",
@@ -20,6 +20,10 @@
     "reference_image_resolution": {
         "height" : 256,
         "width" : 256
+    },
+    "lip_transfer": {
+        "enable": true,
+        "models_dir": "LivePortrait/liveportrait"
     },
     "logging": true
 }

--- a/docs/batch-render-spec.md
+++ b/docs/batch-render-spec.md
@@ -125,6 +125,19 @@ Single job at a time (VRAM). Reject/queue concurrent submits.
 6. `stop()` the instance; mark `done`; expose result.
 On error/cancel at any step: `stop()`, mark state, clean temp files.
 
+### Batch-only deployment (single GPU)
+The live model stays resident for the whole server lifetime, so a second full model
+never co-fits on a 24 GB card. To render batch on one GPU, run a server in
+**batch-only** mode — it skips the live pipeline entirely and gives the per-job
+batch model the GPU to itself:
+```
+FLUXRT_BATCH_ONLY=1 python scripts/run_webrtc.py --config <cfg>   # or --batch-only
+```
+Batch-only implies batch enabled; `/offer` returns 503 and `/healthz` returns a
+minimal `{ready:false, batch_only:true}`. Point a clip's serverBase at it for the
+batch panel (its live connection won't come up — expected). For live + batch
+together, use two GPUs / two servers.
+
 ### VRAM policy
 Two full models (live + batch) may not co-fit. On submit, check free VRAM
 (`get_reserved_memory` / torch). If a batch instance won't fit alongside the live

--- a/docs/batch-render-spec.md
+++ b/docs/batch-render-spec.md
@@ -1,0 +1,185 @@
+# Spec: deterministic frame-for-frame batch render (Route B + park)
+
+Status: implemented (engine + server) · client UI pending · Owner: fluxrt
+
+Implemented: `batch_mode` StreamProcessor (synchronous `submit_frame`, no scheduler,
+`interpolation_exp=0`), `scripts/batch_render.py` (job manager + PyAV decode/encode),
+`scripts/batch_routes.py` (`/batch/jobs` routes), wired in `run_webrtc.py` behind
+`FLUXRT_BATCH_RENDER=1` with a best-effort VRAM preflight + `FLUXRT_BATCH_MAX_MB`
+upload cap. GPU-free tests in `tests/`. Semantics note: output is 1:1 in COUNT and
+reproducible run-to-run, and temporally coherent (frame N builds on the cache of the
+prior frames) — not a per-frame-independent transform. Known caveat: the input video
+is decoded eagerly into memory (bounded by the upload cap); stream-decoding is a
+future improvement.
+
+## Goal
+
+Process a whole input video through the FluxRT pipeline and get **exactly one
+diffused output frame per input frame** — deterministic (seed-stable), in order,
+no dropped/duplicated/interpolated frames — and download it as an mp4.
+
+This is impossible on the **live WebRTC path**: it is a realtime stream that
+(1) drains input to latest (drops frames the pipeline can't keep up with —
+`run_webrtc.py:320-354`), (2) free-runs the diffusion decoupled from input, and
+(3) samples output at a fixed 30 fps with dup/skip (`FluxRTTrack`, `:364-395`).
+So 1:1 needs a **non-realtime, dedicated** path.
+
+## Hard constraint: do NOT reuse the live StreamProcessor (Route A)
+
+The live `sp` is a single free-running pipeline with **one** shared input tensor,
+**one** shared output tensor, **one** global `latest_rgb`, **one** global
+prompt/seed/steps command queue, and **single-instance temporal caches**
+(`UpdateController.cached_frame`, `ModelInferenceSubprocess.previous_frame`, RIFE
+state). Any second caller driving it hijacks the live stream **every frame for the
+whole job**:
+
+- batch input overwrites the live input tensor (`run_webrtc.py:207-209`, one slot
+  `stream_processor.py:25-31`);
+- batch output is written to the single `latest_rgb` → **live viewers see batch
+  frames** (`run_webrtc.py:389-390`, all peers read it);
+- batch prompt/seed/steps mutate global params → live output renders with batch
+  params (`run_webrtc.py:130-132`, `stream_processor.py:87-103`);
+- temporal caches diff/blend batch-vs-live frames → ghosting at boundaries.
+
+Pausing the live producer (`peer_input_active`) + time-slicing does **not** fix
+this (param-swap latency ≥1 diffusion iter, temporal-cache pollution, drain-to-
+latest still flashes batch to live). Conclusion: **separate instance only.**
+
+## Architecture: a second, parked StreamProcessor
+
+Add a **batch StreamProcessor** instance, separate from the live one. It has its
+own subprocesses + shared memory + global params + temporal caches → **zero shared
+state** with the live stream.
+
+```
+                    ┌─────────────────────────────┐
+ live WebRTC  ─────▶│ live StreamProcessor (sp)    │──▶ FluxRTTrack (30fps, realtime)
+                    └─────────────────────────────┘
+                    ┌─────────────────────────────┐
+ POST /batch  ─────▶│ batch StreamProcessor        │──▶ mp4 (1:1, deterministic)
+ (video)            │  · interpolation_exp = 0     │
+                    │  · synchronous single-step   │
+                    │  · parked when no job         │
+                    └─────────────────────────────┘
+```
+
+### Three required engine changes (the load-bearing work)
+
+1. **Synchronous single-frame API.** Today the inference subprocess free-runs
+   (`model_inference_subprocess.py:642-655`: unconditional `while running: read-
+   latest → diffuse → write`) with no input gate, no frame-id, no handshake. Add a
+   **batch/synchronous mode** to the subprocess: a request queue of `(seq, rgb)` →
+   response queue of `(seq, rgb_out)`, processed strictly in order, one diffusion
+   per request, blocking until that frame's output is produced. Expose on
+   `StreamProcessor` as e.g. `submit_frame(rgb: np.ndarray) -> np.ndarray`
+   (blocking) — used ONLY by the batch instance. The live free-run path is
+   untouched (mode flag selected at construction).
+
+2. **Disable interpolation for batch.** Construct the batch instance with
+   `interpolation_exp = 0` → `batch_size = 2**0 = 1` (`output_scheduler_subprocess
+   .py:26-27`, `model_inference_subprocess.py:360`). One diffused output per input,
+   no RIFE tweening. (Batch does not need the output scheduler's fps pacing at all —
+   in sync mode the response queue is the output.)
+
+3. **Per-job temporal state.** Keep `cached_frame` / `previous_frame` / KV caches
+   (they give frame-to-frame temporal coherence across the video — desirable). They
+   are already per-instance, so no live pollution. **Reset them at job START**
+   (fresh video) — reuse the existing `requires_reset` / prompt-embed reset path.
+   Set prompt/seed/steps **once per job** before the first `submit_frame`.
+
+### Park lifecycle (zero idle cost)
+
+The inference subprocess loop has **no idle gate** — a started-but-jobless instance
+still pegs the GPU every iteration (`model_inference_subprocess.py:642-655`). So:
+
+- **Default: spawn-on-submit, teardown-on-complete.** Create + `start()` the batch
+  instance when a job arrives; `stop()` (`running.value=False`, joins subprocesses)
+  when it finishes/cancels. Idle → instance does not exist → **zero VRAM, zero GPU**.
+  Cost: model load (~seconds) per job — acceptable for an offline feature.
+- **Optional keep-warm** (frequent jobs): keep the instance resident but add an
+  **input-changed/idle gate** to the loop (sleep when no pending request) so an idle
+  warm instance frees GPU compute. Still holds VRAM. Make it a config flag
+  (`batch_keep_warm: false` default).
+
+## Server API (FastAPI, in or alongside `run_webrtc.py`)
+
+Single job at a time (VRAM). Reject/queue concurrent submits.
+
+| Method | Path | Body / Query | Returns |
+|---|---|---|---|
+| POST | `/batch/jobs` | multipart video file + `prompt,seed,steps,fps?` | `{job_id}` (202) |
+| GET | `/batch/jobs/{id}` | — | `{state, frames_done, frames_total, fps, eta_s}` |
+| GET | `/batch/jobs/{id}/result` | — | mp4 stream (200) when `state==done` |
+| DELETE | `/batch/jobs/{id}` | — | cancel → `stop()` the instance |
+
+`state ∈ {queued, loading, running, encoding, done, error, canceled}`.
+
+### Server job flow
+1. Decode input video → frames (pyav/ffmpeg), note its fps + frame count.
+2. Spawn batch StreamProcessor (`interpolation_exp=0`), `start()`, wait `is_ready()`.
+3. Reset temporal caches; `set_prompt/seed/steps` once.
+4. For each input frame in order: `out = batch_sp.submit_frame(rgb)`; append; bump
+   `frames_done`.
+5. Encode outputs → mp4 (pyav/ffmpeg, **CFR at input fps**, H.264). Exactly
+   `frames_total` output frames.
+6. `stop()` the instance; mark `done`; expose result.
+On error/cancel at any step: `stop()`, mark state, clean temp files.
+
+### VRAM policy
+Two full models (live + batch) may not co-fit. On submit, check free VRAM
+(`get_reserved_memory` / torch). If a batch instance won't fit alongside the live
+one:
+- **Option 1 (default):** reject with `409 {detail: "stop the live stream to run a
+  batch render"}` — surfaced in the client.
+- **Option 2 (config):** auto-pause/stop the live stream for the job duration, then
+  resume. Document the live interruption.
+
+## Client UI (realtime-client)
+
+New batch panel in the FluxRT detail (separate from the live record toggle in
+PR #29). Job-style, not a live toggle:
+
+```
+FluxRT detail ▸ Config ▸ Batch render ▾
+  [ ⬇ drop video · or 📂 choose ]
+  prompt <current>   seed [52]  steps [2]   fps [source]
+  [▶ Render frame-for-frame]
+  ▓▓▓▓▓▓░░░░  142 / 360  39%  ~0:48 left        ← poll GET /batch/jobs/{id}
+  ✓ fluxrt-render-<ts>.mp4   [download]          ← GET …/result
+```
+
+- POST the video + params → `job_id`; poll status (1–2s); show progress/eta.
+- On `done`, download the mp4. On `409` (VRAM), show "stop live stream to render".
+- One job at a time; disable submit while a job runs.
+
+## Acceptance criteria
+
+- Output frame count **== input frame count** (1:1; verify with ffprobe).
+- Output is **CFR at input fps**; no dropped/duplicated/interpolated frames.
+- **Deterministic**: same input+prompt+seed+steps → byte-stable (or
+  pixel-identical) output across runs.
+- **No live impact while idle**: with no batch job, live FPS unchanged (instance
+  not resident / parked). Measure live `fps_pipeline` before/after.
+- **No live state corruption while a batch runs** (separate instance): live
+  prompt/seed/output unaffected (GPU contention/FPS drop is expected + acceptable,
+  or avoided via the VRAM policy).
+- Cancel + error paths always `stop()` the batch instance (no leaked subprocess /
+  shared memory / VRAM).
+
+## Out of scope / alternatives considered
+
+- **Reuse live `sp` (Route A):** rejected — hijacks the live stream (see above).
+- **Single-`sp` multi-stream refactor:** per-stream input/output tensor slots +
+  per-slot params + per-stream temporal caches. Larger than Route B and touches the
+  live hot path — not worth it for an offline feature.
+- **Lockstep over free-run (no sync API):** fragile — no frame-id in the output
+  tensor, timing-based polling races the free-run loop. The sync API is the clean
+  version.
+
+## Effort estimate
+
+- Engine: synchronous single-frame mode in `model_inference_subprocess` +
+  `StreamProcessor.submit_frame` + `interpolation_exp=0` construction + per-job
+  reset — **M** (the sync mode is the bulk; the rest is wiring/config).
+- Server: 4 endpoints + decode/encode + job manager + VRAM gate — **S–M**.
+- Client: batch panel + polling — **S**.

--- a/requirements_webrtc.txt
+++ b/requirements_webrtc.txt
@@ -3,3 +3,4 @@ av>=12
 fastapi>=0.115
 uvicorn[standard]>=0.30
 httpx>=0.27
+python-multipart>=0.0.9

--- a/requirements_webrtc.txt
+++ b/requirements_webrtc.txt
@@ -1,0 +1,5 @@
+aiortc>=1.9
+av>=12
+fastapi>=0.115
+uvicorn[standard]>=0.30
+httpx>=0.27

--- a/scripts/batch_render.py
+++ b/scripts/batch_render.py
@@ -1,0 +1,297 @@
+"""Offline batch frame-for-frame render.
+
+Runs a whole video through a DEDICATED StreamProcessor (batch_mode): exactly one
+output frame per input frame, in order, with no drop / dup / fps-resampling /
+interpolation (unlike the realtime live path). The render is temporally coherent
+(each frame builds on the spatial cache of the ones before it, like the live
+stream) and reproducible run-to-run for the same input+prompt+seed+steps — it is
+NOT a per-frame-independent transform.
+
+The dedicated instance shares no tensors / params / temporal caches with the live
+WebRTC stream, so it cannot corrupt it (only GPU/VRAM is shared while a job runs).
+The instance is created on submit and torn down on completion, so idle costs zero
+GPU/VRAM. See docs/batch-render-spec.md.
+
+The StreamProcessor is injected (`make_processor`) so the manager + video IO are
+testable without CUDA (pass a stub that echoes frames).
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import tempfile
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from fractions import Fraction
+from typing import Callable, List, Optional
+
+import av
+import numpy as np
+
+
+# ── Video IO (PyAV) ───────────────────────────────────────────────────────────
+def decode_video(path: str) -> tuple[List[np.ndarray], Optional[Fraction]]:
+    """Decode every frame in order. Returns (frames as uint8 RGB HxWx3, fps).
+    fps is the exact rational rate (e.g. 30000/1001) so CFR timing is preserved."""
+    container = av.open(path)
+    try:
+        stream = container.streams.video[0]
+        fps = stream.average_rate  # a Fraction, or None for unknown
+        frames = [f.to_ndarray(format="rgb24") for f in container.decode(stream)]
+    finally:
+        container.close()
+    return frames, fps
+
+
+class Mp4Encoder:
+    """Streaming H.264 mp4 encoder — write() one RGB frame at a time (CFR), so the
+    full output never has to be held in memory. close() is idempotent."""
+
+    def __init__(self, path: str, fps, width: int, height: int):
+        rate = fps if isinstance(fps, Fraction) else Fraction(fps or 25).limit_denominator(1000000)
+        self._container = av.open(path, mode="w")
+        self._stream = self._container.add_stream("libx264", rate=rate)
+        self._stream.width = width
+        self._stream.height = height
+        self._stream.pix_fmt = "yuv420p"
+        self._closed = False
+
+    def write(self, frame_rgb: np.ndarray) -> None:
+        vf = av.VideoFrame.from_ndarray(np.ascontiguousarray(frame_rgb), format="rgb24")
+        for packet in self._stream.encode(vf):
+            self._container.mux(packet)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        for packet in self._stream.encode():  # flush
+            self._container.mux(packet)
+        self._container.close()
+
+
+# ── Job state ─────────────────────────────────────────────────────────────────
+JOB_STATES = ("queued", "loading", "running", "encoding", "done", "error", "canceled")
+_TERMINAL = ("done", "error", "canceled")
+
+
+@dataclass
+class BatchJob:
+    id: str
+    prompt: str
+    seed: int
+    steps: int
+    fps: Optional[float]
+    state: str = "queued"
+    frames_total: int = 0
+    frames_done: int = 0
+    error: str = ""
+    out_path: Optional[str] = None
+    started_at: float = field(default_factory=time.time)
+    _cancel: threading.Event = field(default_factory=threading.Event)
+    _thread: Optional[threading.Thread] = None
+
+    def status(self) -> dict:
+        elapsed = time.time() - self.started_at
+        eta = 0.0
+        if self.frames_done and self.frames_total:
+            per = elapsed / self.frames_done
+            eta = max(0.0, per * (self.frames_total - self.frames_done))
+        return {
+            "id": self.id,
+            "state": self.state,
+            "frames_total": self.frames_total,
+            "frames_done": self.frames_done,
+            "fps": self.fps,
+            "eta_s": round(eta, 1),
+            "error": self.error,
+        }
+
+
+# make_processor(config_dict) -> object with:
+#   start(), is_ready()->bool, set_prompt(str), set_seed(int), set_steps(int),
+#   submit_frame(rgb)->rgb, stop(), and (optionally) worker_alive()->bool
+ProcessorFactory = Callable[[dict], object]
+
+# Bounded model-load wait: if the second model is not ready within this, the child
+# almost certainly died (CUDA OOM) — fail the job instead of spinning forever.
+_LOAD_TIMEOUT_S = 180.0
+
+
+class BatchJobManager:
+    """One job at a time (a second full model in VRAM). A worker thread spawns a
+    dedicated batch StreamProcessor, renders frame-by-frame, streams the mp4, then
+    tears the processor down. Finished jobs are retained (most-recent N) so their
+    result can be downloaded; older ones are pruned and their files deleted."""
+
+    def __init__(
+        self,
+        base_config: dict,
+        make_processor: ProcessorFactory,
+        out_dir: Optional[str] = None,
+        preflight: Optional[Callable[[], None]] = None,
+        max_retained: int = 20,
+    ):
+        self._base_config = base_config
+        self._make = make_processor
+        self._out_dir = out_dir or tempfile.gettempdir()
+        self._preflight = preflight  # may raise RuntimeError (e.g. insufficient VRAM)
+        self._max_retained = max_retained
+        self._lock = threading.Lock()
+        self._jobs: dict[str, BatchJob] = {}
+        self._active: Optional[str] = None
+
+    def submit(self, video_bytes: bytes, prompt: str, seed: int, steps: int, fps: Optional[float]) -> BatchJob:
+        with self._lock:
+            if self._active is not None:
+                raise RuntimeError("a batch render is already running")
+            if self._preflight is not None:
+                self._preflight()  # raises -> surfaced as 409 by the route
+            self._prune_locked()
+            job = BatchJob(id=uuid.uuid4().hex[:12], prompt=prompt, seed=seed, steps=steps, fps=fps)
+            self._jobs[job.id] = job
+            self._active = job.id
+        job._thread = threading.Thread(target=self._run, args=(job, video_bytes), daemon=True)
+        job._thread.start()
+        return job
+
+    def get(self, job_id: str) -> Optional[BatchJob]:
+        return self._jobs.get(job_id)
+
+    def active_job_id(self) -> Optional[str]:
+        return self._active
+
+    def cancel(self, job_id: str) -> bool:
+        job = self._jobs.get(job_id)
+        if not job:
+            return False
+        job._cancel.set()
+        return True
+
+    def shutdown(self, timeout: float = 10.0) -> None:
+        """Cancel the active job and give its worker a bounded chance to tear the
+        batch processor down (so the 2nd model's subprocess + shared memory aren't
+        orphaned at interpreter exit)."""
+        active = self._active
+        if not active:
+            return
+        self.cancel(active)
+        job = self._jobs.get(active)
+        thread = job._thread if job else None
+        if thread is not None:
+            thread.join(timeout)
+
+    def _prune_locked(self) -> None:
+        finished = [j for j in self._jobs.values() if j.state in _TERMINAL]
+        if len(finished) <= self._max_retained:
+            return
+        finished.sort(key=lambda j: j.started_at)
+        for j in finished[: len(finished) - self._max_retained]:
+            if j.out_path and os.path.exists(j.out_path):
+                try:
+                    os.unlink(j.out_path)
+                except OSError:
+                    pass
+            self._jobs.pop(j.id, None)
+
+    def _batch_config(self) -> dict:
+        # deepcopy so nested dicts (resolution, lip_transfer, …) are NOT shared with
+        # the live sp.config — the batch instance must not mutate the live byte path.
+        cfg = copy.deepcopy(self._base_config)
+        cfg["batch_mode"] = True
+        cfg["interpolation_exp"] = 0  # exactly 1 output per input (no RIFE tween)
+        cfg["logging"] = False
+        # A second model + LivePortrait would OOM; batch never lip-syncs.
+        lp = cfg.get("lip_transfer")
+        if isinstance(lp, dict):
+            lp["enable"] = False
+        return cfg
+
+    def _run(self, job: BatchJob, video_bytes: bytes) -> None:
+        proc = None
+        encoder = None
+        in_path = None
+        out_path = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+                f.write(video_bytes)
+                in_path = f.name
+            frames, src_fps = decode_video(in_path)
+            if not frames:
+                raise ValueError("no frames decoded from input video")
+            job.frames_total = len(frames)
+            out_fps = job.fps or src_fps or 25.0
+
+            job.state = "loading"
+            proc = self._make(self._batch_config())
+            proc.start()
+            # Wait for the model to load, but fail fast if the child dies (CUDA OOM)
+            # or never becomes ready — otherwise this loop (and the single job slot)
+            # would hang forever.
+            alive = getattr(proc, "worker_alive", None)
+            load_deadline = time.time() + _LOAD_TIMEOUT_S
+            while not proc.is_ready():
+                if job._cancel.is_set():
+                    raise _Canceled()
+                if alive is not None and not alive():
+                    raise RuntimeError("batch inference subprocess died during model load (likely CUDA OOM)")
+                if time.time() >= load_deadline:
+                    raise RuntimeError("batch processor failed to become ready within the load timeout")
+                time.sleep(0.1)
+            # Params applied once, before the first frame (drained on the first render).
+            proc.set_prompt(job.prompt)
+            proc.set_seed(job.seed)
+            proc.set_steps(job.steps)
+
+            job.state = "running"
+            out_path = os.path.join(self._out_dir, f"fluxrt-render-{job.id}.mp4")
+            for i, fr in enumerate(frames):
+                if job._cancel.is_set():
+                    raise _Canceled()
+                out = proc.submit_frame(fr)
+                if encoder is None:  # size the encoder from the first output (may be upscaled)
+                    encoder = Mp4Encoder(out_path, out_fps, out.shape[1], out.shape[0])
+                encoder.write(out)
+                job.frames_done = i + 1
+
+            job.state = "encoding"
+            encoder.close()
+            encoder = None
+            job.out_path = out_path
+            job.state = "done"
+        except _Canceled:
+            job.state = "canceled"
+        except Exception as exc:  # noqa: BLE001 — surface any failure as job state
+            job.error = str(exc)
+            job.state = "error"
+        finally:
+            if encoder is not None:
+                try:
+                    encoder.close()
+                except Exception:
+                    pass
+            if proc is not None:
+                try:
+                    proc.stop()  # park: frees the 2nd model's VRAM/GPU when idle
+                except Exception:
+                    pass
+            # A canceled/failed job keeps no file; only a completed render is retained.
+            if job.state in ("canceled", "error") and out_path and os.path.exists(out_path):
+                try:
+                    os.unlink(out_path)
+                except OSError:
+                    pass
+            if in_path and os.path.exists(in_path):
+                try:
+                    os.unlink(in_path)
+                except OSError:
+                    pass
+            with self._lock:
+                self._active = None
+
+
+class _Canceled(Exception):
+    pass

--- a/scripts/batch_render.py
+++ b/scripts/batch_render.py
@@ -145,6 +145,7 @@ class BatchJobManager:
         self._lock = threading.Lock()
         self._jobs: dict[str, BatchJob] = {}
         self._active: Optional[str] = None
+        self._active_proc = None  # the running batch StreamProcessor (for live prompt steering)
 
     def submit(self, video_bytes: bytes, prompt: str, seed: int, steps: int, fps: Optional[float], interp: Optional[int] = None) -> BatchJob:
         with self._lock:
@@ -168,6 +169,29 @@ class BatchJobManager:
 
     def active_job_id(self) -> Optional[str]:
         return self._active
+
+    def set_prompt(self, text: str) -> bool:
+        """Live-steer the running render's prompt (hard cut). No-op if no job runs.
+        Applied on the next rendered frame (the worker drains the command queue)."""
+        p = self._active_proc
+        if p is None:
+            return False
+        try:
+            p.set_prompt(text)
+            return True
+        except Exception:
+            return False
+
+    def start_prompt_travel(self, text: str, frames: int = 48, mode: str = "slerp") -> bool:
+        """Live-steer with a slerp/lerp morph over the next `frames` rendered frames."""
+        p = self._active_proc
+        if p is None:
+            return False
+        try:
+            p.start_prompt_travel(text, frames=frames, mode=mode)
+            return True
+        except Exception:
+            return False
 
     def cancel(self, job_id: str) -> bool:
         job = self._jobs.get(job_id)
@@ -237,6 +261,7 @@ class BatchJobManager:
 
             job.state = "loading"
             proc = self._make(self._batch_config(job.interp))
+            self._active_proc = proc  # exposed for live prompt steering
             proc.start()
             # Wait for the model to load, but fail fast if the child dies (CUDA OOM)
             # or never becomes ready — otherwise this loop (and the single job slot)
@@ -300,6 +325,7 @@ class BatchJobManager:
                     os.unlink(in_path)
                 except OSError:
                     pass
+            self._active_proc = None
             with self._lock:
                 self._active = None
 

--- a/scripts/batch_render.py
+++ b/scripts/batch_render.py
@@ -146,6 +146,7 @@ class BatchJobManager:
         self._jobs: dict[str, BatchJob] = {}
         self._active: Optional[str] = None
         self._active_proc = None  # the running batch StreamProcessor (for live prompt steering)
+        self._latest_frame = None  # most recent rendered frame (RGB), for the live preview
 
     def submit(self, video_bytes: bytes, prompt: str, seed: int, steps: int, fps: Optional[float], interp: Optional[int] = None) -> BatchJob:
         with self._lock:
@@ -169,6 +170,16 @@ class BatchJobManager:
 
     def active_job_id(self) -> Optional[str]:
         return self._active
+
+    def latest_jpeg(self) -> Optional[bytes]:
+        """JPEG of the most recently rendered frame (for the live preview), or None."""
+        frame = self._latest_frame
+        if frame is None:
+            return None
+        import cv2  # lazy: keeps the GPU-free test import torch/cv2-free
+
+        ok, buf = cv2.imencode(".jpg", frame[:, :, ::-1])  # RGB -> BGR for cv2
+        return buf.tobytes() if ok else None
 
     def set_prompt(self, text: str) -> bool:
         """Live-steer the running render's prompt (hard cut). No-op if no job runs.
@@ -260,6 +271,7 @@ class BatchJobManager:
             out_fps = (job.fps or src_fps or 25.0) * factor
 
             job.state = "loading"
+            self._latest_frame = None  # drop the previous render's last frame
             proc = self._make(self._batch_config(job.interp))
             self._active_proc = proc  # exposed for live prompt steering
             proc.start()
@@ -291,6 +303,7 @@ class BatchJobManager:
                     if encoder is None:  # size the encoder from the first output (may be upscaled)
                         encoder = Mp4Encoder(out_path, out_fps, out.shape[1], out.shape[0])
                     encoder.write(out)
+                    self._latest_frame = out  # live preview tracks the latest rendered frame
                 job.frames_done = i + 1
 
             job.state = "encoding"

--- a/scripts/batch_render.py
+++ b/scripts/batch_render.py
@@ -146,14 +146,17 @@ class BatchJobManager:
         self._jobs: dict[str, BatchJob] = {}
         self._active: Optional[str] = None
 
-    def submit(self, video_bytes: bytes, prompt: str, seed: int, steps: int, fps: Optional[float], interp: int = 0) -> BatchJob:
+    def submit(self, video_bytes: bytes, prompt: str, seed: int, steps: int, fps: Optional[float], interp: Optional[int] = None) -> BatchJob:
         with self._lock:
             if self._active is not None:
                 raise RuntimeError("a batch render is already running")
             if self._preflight is not None:
                 self._preflight()  # raises -> surfaced as 409 by the route
             self._prune_locked()
-            job = BatchJob(id=uuid.uuid4().hex[:12], prompt=prompt, seed=seed, steps=steps, fps=fps, interp=max(0, min(4, int(interp))))
+            # interp=None inherits the server's interpolation_exp (the --interp flag /
+            # config); an explicit value (e.g. from the UI) overrides it.
+            interp_v = self._base_config.get("interpolation_exp", 0) if interp is None else interp
+            job = BatchJob(id=uuid.uuid4().hex[:12], prompt=prompt, seed=seed, steps=steps, fps=fps, interp=max(0, min(4, int(interp_v))))
             self._jobs[job.id] = job
             self._active = job.id
         job._thread = threading.Thread(target=self._run, args=(job, video_bytes), daemon=True)

--- a/scripts/batch_render.py
+++ b/scripts/batch_render.py
@@ -85,6 +85,7 @@ class BatchJob:
     seed: int
     steps: int
     fps: Optional[float]
+    interp: int = 0  # RIFE interpolation exponent: 0 = 1:1, k>0 = 2**k frames per input
     state: str = "queued"
     frames_total: int = 0
     frames_done: int = 0
@@ -106,6 +107,7 @@ class BatchJob:
             "frames_total": self.frames_total,
             "frames_done": self.frames_done,
             "fps": self.fps,
+            "interp": self.interp,
             "eta_s": round(eta, 1),
             "error": self.error,
         }
@@ -144,14 +146,14 @@ class BatchJobManager:
         self._jobs: dict[str, BatchJob] = {}
         self._active: Optional[str] = None
 
-    def submit(self, video_bytes: bytes, prompt: str, seed: int, steps: int, fps: Optional[float]) -> BatchJob:
+    def submit(self, video_bytes: bytes, prompt: str, seed: int, steps: int, fps: Optional[float], interp: int = 0) -> BatchJob:
         with self._lock:
             if self._active is not None:
                 raise RuntimeError("a batch render is already running")
             if self._preflight is not None:
                 self._preflight()  # raises -> surfaced as 409 by the route
             self._prune_locked()
-            job = BatchJob(id=uuid.uuid4().hex[:12], prompt=prompt, seed=seed, steps=steps, fps=fps)
+            job = BatchJob(id=uuid.uuid4().hex[:12], prompt=prompt, seed=seed, steps=steps, fps=fps, interp=max(0, min(4, int(interp))))
             self._jobs[job.id] = job
             self._active = job.id
         job._thread = threading.Thread(target=self._run, args=(job, video_bytes), daemon=True)
@@ -197,12 +199,14 @@ class BatchJobManager:
                     pass
             self._jobs.pop(j.id, None)
 
-    def _batch_config(self) -> dict:
+    def _batch_config(self, interp: int) -> dict:
         # deepcopy so nested dicts (resolution, lip_transfer, …) are NOT shared with
         # the live sp.config — the batch instance must not mutate the live byte path.
         cfg = copy.deepcopy(self._base_config)
         cfg["batch_mode"] = True
-        cfg["interpolation_exp"] = 0  # exactly 1 output per input (no RIFE tween)
+        # 0 = exactly one output per input (1:1); k>0 = RIFE-interpolate 2**k frames
+        # per input (the encoder fps is scaled by the same factor).
+        cfg["interpolation_exp"] = max(0, min(4, int(interp)))
         cfg["logging"] = False
         # A second model + LivePortrait would OOM; batch never lip-syncs.
         lp = cfg.get("lip_transfer")
@@ -223,10 +227,13 @@ class BatchJobManager:
             if not frames:
                 raise ValueError("no frames decoded from input video")
             job.frames_total = len(frames)
-            out_fps = job.fps or src_fps or 25.0
+            # Interpolation emits 2**interp frames per input, so scale the encoded fps
+            # by the same factor to keep the output the same duration (just smoother).
+            factor = 2 ** job.interp
+            out_fps = (job.fps or src_fps or 25.0) * factor
 
             job.state = "loading"
-            proc = self._make(self._batch_config())
+            proc = self._make(self._batch_config(job.interp))
             proc.start()
             # Wait for the model to load, but fail fast if the child dies (CUDA OOM)
             # or never becomes ready — otherwise this loop (and the single job slot)
@@ -251,10 +258,11 @@ class BatchJobManager:
             for i, fr in enumerate(frames):
                 if job._cancel.is_set():
                     raise _Canceled()
-                out = proc.submit_frame(fr)
-                if encoder is None:  # size the encoder from the first output (may be upscaled)
-                    encoder = Mp4Encoder(out_path, out_fps, out.shape[1], out.shape[0])
-                encoder.write(out)
+                # submit_frame returns a LIST (one frame, or 2**interp interpolated).
+                for out in proc.submit_frame(fr):
+                    if encoder is None:  # size the encoder from the first output (may be upscaled)
+                        encoder = Mp4Encoder(out_path, out_fps, out.shape[1], out.shape[0])
+                    encoder.write(out)
                 job.frames_done = i + 1
 
             job.state = "encoding"

--- a/scripts/batch_routes.py
+++ b/scripts/batch_routes.py
@@ -36,10 +36,11 @@ def make_batch_router(
         seed: int = Form(...),
         steps: int = Form(...),
         fps: Optional[float] = Form(None),
-        interp: int = Form(0),
+        interp: Optional[int] = Form(None),
     ):
-        """Start an offline render of an uploaded video. interp=0 → 1:1; k>0 → RIFE
-        interpolation (2**k frames per input). 202 + job status."""
+        """Start an offline render of an uploaded video. interp omitted → inherit the
+        server's --interp; 0 → 1:1; k>0 → RIFE interpolation (2**k frames per input).
+        202 + job status."""
         _require()
         size = getattr(video, "size", None)  # set by Starlette from the multipart part
         if size is not None and size > _MAX_UPLOAD_BYTES:
@@ -56,7 +57,7 @@ def make_batch_router(
                 seed=int(seed),
                 steps=int(steps),
                 fps=fps,
-                interp=int(interp),
+                interp=None if interp is None else int(interp),
             )
         except RuntimeError as exc:  # another job already running
             raise HTTPException(status_code=409, detail=str(exc))

--- a/scripts/batch_routes.py
+++ b/scripts/batch_routes.py
@@ -36,8 +36,10 @@ def make_batch_router(
         seed: int = Form(...),
         steps: int = Form(...),
         fps: Optional[float] = Form(None),
+        interp: int = Form(0),
     ):
-        """Start an offline 1:1 render of an uploaded video. 202 + job status."""
+        """Start an offline render of an uploaded video. interp=0 → 1:1; k>0 → RIFE
+        interpolation (2**k frames per input). 202 + job status."""
         _require()
         size = getattr(video, "size", None)  # set by Starlette from the multipart part
         if size is not None and size > _MAX_UPLOAD_BYTES:
@@ -54,6 +56,7 @@ def make_batch_router(
                 seed=int(seed),
                 steps=int(steps),
                 fps=fps,
+                interp=int(interp),
             )
         except RuntimeError as exc:  # another job already running
             raise HTTPException(status_code=409, detail=str(exc))

--- a/scripts/batch_routes.py
+++ b/scripts/batch_routes.py
@@ -1,0 +1,87 @@
+"""FastAPI routes for the offline batch render, as a router factory so they can be
+mounted in run_webrtc.py AND tested standalone against a stub job manager (no CUDA,
+no torch). The manager + enabled-flag + default-prompt are injected."""
+
+from __future__ import annotations
+
+import os
+from typing import Callable, Optional
+
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from fastapi.responses import FileResponse, JSONResponse
+
+# Cap the uploaded video so a single request can't exhaust host RAM (the whole file
+# is buffered, then decoded). Override with FLUXRT_BATCH_MAX_MB.
+_MAX_UPLOAD_BYTES = int(os.environ.get("FLUXRT_BATCH_MAX_MB", "256")) * 1024 * 1024
+
+
+def make_batch_router(
+    get_manager: Callable[[], object],
+    is_enabled: Callable[[], bool],
+    default_prompt: Callable[[], str] = lambda: "",
+) -> APIRouter:
+    router = APIRouter()
+
+    def _require() -> None:
+        if not is_enabled():
+            raise HTTPException(
+                status_code=503,
+                detail="Batch render not enabled. Set FLUXRT_BATCH_RENDER=1 on a host with spare GPU/VRAM (a second full model will not co-fit with the live stream on 24 GB).",
+            )
+
+    @router.post("/batch/jobs")
+    async def submit(
+        video: UploadFile = File(...),
+        prompt: str = Form(""),
+        seed: int = Form(...),
+        steps: int = Form(...),
+        fps: Optional[float] = Form(None),
+    ):
+        """Start an offline 1:1 render of an uploaded video. 202 + job status."""
+        _require()
+        size = getattr(video, "size", None)  # set by Starlette from the multipart part
+        if size is not None and size > _MAX_UPLOAD_BYTES:
+            raise HTTPException(status_code=413, detail=f"video exceeds {_MAX_UPLOAD_BYTES // (1024 * 1024)} MB limit")
+        data = await video.read()
+        if not data:
+            raise HTTPException(status_code=400, detail="empty video upload")
+        if len(data) > _MAX_UPLOAD_BYTES:
+            raise HTTPException(status_code=413, detail=f"video exceeds {_MAX_UPLOAD_BYTES // (1024 * 1024)} MB limit")
+        try:
+            job = get_manager().submit(
+                data,
+                prompt=prompt or default_prompt(),
+                seed=int(seed),
+                steps=int(steps),
+                fps=fps,
+            )
+        except RuntimeError as exc:  # another job already running
+            raise HTTPException(status_code=409, detail=str(exc))
+        return JSONResponse(job.status(), status_code=202)
+
+    @router.get("/batch/jobs/{job_id}")
+    async def status(job_id: str):
+        _require()
+        job = get_manager().get(job_id)
+        if not job:
+            raise HTTPException(status_code=404, detail="no such job")
+        return job.status()
+
+    @router.get("/batch/jobs/{job_id}/result")
+    async def result(job_id: str):
+        _require()
+        job = get_manager().get(job_id)
+        if not job:
+            raise HTTPException(status_code=404, detail="no such job")
+        if job.state != "done" or not job.out_path or not os.path.exists(job.out_path):
+            raise HTTPException(status_code=409, detail=f"job not done (state={job.state})")
+        return FileResponse(job.out_path, media_type="video/mp4", filename=f"fluxrt-render-{job.id}.mp4")
+
+    @router.delete("/batch/jobs/{job_id}")
+    async def cancel(job_id: str):
+        _require()
+        if not get_manager().cancel(job_id):
+            raise HTTPException(status_code=404, detail="no such job")
+        return {"ok": True}
+
+    return router

--- a/scripts/batch_routes.py
+++ b/scripts/batch_routes.py
@@ -8,7 +8,7 @@ import os
 from typing import Callable, Optional
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import FileResponse, JSONResponse, Response
 
 # Cap the uploaded video so a single request can't exhaust host RAM (the whole file
 # is buffered, then decoded). Override with FLUXRT_BATCH_MAX_MB.
@@ -62,6 +62,15 @@ def make_batch_router(
         except RuntimeError as exc:  # another job already running
             raise HTTPException(status_code=409, detail=str(exc))
         return JSONResponse(job.status(), status_code=202)
+
+    @router.get("/batch/preview.jpg")
+    async def preview():
+        """Latest rendered frame as a JPEG, for a live preview while a job runs."""
+        _require()
+        jpg = get_manager().latest_jpeg()
+        if jpg is None:
+            raise HTTPException(status_code=404, detail="no rendered frame yet")
+        return Response(content=jpg, media_type="image/jpeg", headers={"Cache-Control": "no-store"})
 
     @router.get("/batch/jobs/{job_id}")
     async def status(job_id: str):

--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -68,17 +68,21 @@ IF ERRORLEVEL 1 (
     exit /b 1
 )
 
-:: ── PyTorch ───────────────────────────────────────────────────────────────────
-python -c "import torch" >nul 2>&1
+:: ── PyTorch (CUDA 12.8 / Blackwell sm_120 for RTX 50-series) ──────────────────
+:: Check the build actually carries sm_120 kernels, not just that torch imports.
+:: A cu128 wheel lists sm_120 regardless of the local GPU and also covers the
+:: RTX 4090 (sm_89); a CPU or pre-cu128 torch fails on a 5090. --upgrade replaces
+:: such a build in place.
+python -c "import torch, sys; sys.exit(0 if 'sm_120' in torch.cuda.get_arch_list() else 1)" >nul 2>&1
 IF ERRORLEVEL 1 (
-    echo [+] Installing PyTorch with CUDA 12.8 support...
-    pip install torch torchvision --index-url https://download.pytorch.org/whl/cu128
+    echo [+] Installing PyTorch with CUDA 12.8 / Blackwell sm_120 support...
+    pip install --upgrade torch torchvision --index-url https://download.pytorch.org/whl/cu128
     IF ERRORLEVEL 1 (
         echo [ERROR] Failed to install PyTorch.
         exit /b 1
     )
 ) ELSE (
-    echo [+] PyTorch is already installed.
+    echo [+] PyTorch with Blackwell sm_120 support already installed.
 )
 
 :: ── Python requirements ───────────────────────────────────────────────────────
@@ -189,6 +193,53 @@ IF EXIST "%INT8_SENTINEL%" (
         exit /b 1
     )
 )
+
+:: ── TAEF2 tiny-VAE model (extension) ─────────────────────────────────────────
+SET TAEF2_DIR=taef2
+SET TAEF2_SENTINEL=taef2\taef2.safetensors
+IF EXIST "%TAEF2_SENTINEL%" (
+    echo [+] TAEF2 tiny-VAE model: already downloaded.
+) ELSE IF EXIST "%TAEF2_DIR%\.git" (
+    echo [!] TAEF2: directory exists but looks incomplete — resuming LFS download...
+    git -C "%TAEF2_DIR%" pull --ff-only
+    git -C "%TAEF2_DIR%" lfs pull
+) ELSE IF EXIST "%TAEF2_DIR%" (
+    echo [!] TAEF2: '%TAEF2_DIR%' exists but is not a git repository.
+    echo [!]        Remove it and re-run to download the model.
+) ELSE (
+    echo [+] Downloading TAEF2 tiny-VAE model...
+    git clone https://huggingface.co/madebyollin/taef2
+    IF ERRORLEVEL 1 (
+        echo [ERROR] Failed to clone TAEF2 model.
+        exit /b 1
+    )
+)
+
+:: ── Flow Upscaler model (extension) ──────────────────────────────────────────
+SET UPSCALER_DIR=FlowUpscaler
+SET UPSCALER_SENTINEL=FlowUpscaler\flow_upscaler.safetensors
+IF EXIST "%UPSCALER_SENTINEL%" (
+    echo [+] Flow Upscaler model: already downloaded.
+) ELSE IF EXIST "%UPSCALER_DIR%\.git" (
+    echo [!] Flow Upscaler: directory exists but looks incomplete — resuming LFS download...
+    git -C "%UPSCALER_DIR%" pull --ff-only
+    git -C "%UPSCALER_DIR%" lfs pull
+) ELSE IF EXIST "%UPSCALER_DIR%" (
+    echo [!] Flow Upscaler: '%UPSCALER_DIR%' exists but is not a git repository.
+    echo [!]               Remove it and re-run to download the model.
+) ELSE (
+    echo [+] Downloading Flow Upscaler model...
+    git clone https://huggingface.co/TensorForger/FlowUpscaler
+    IF ERRORLEVEL 1 (
+        echo [ERROR] Failed to clone Flow Upscaler model.
+        exit /b 1
+    )
+)
+
+:: ── verify GPU detection ──────────────────────────────────────────────────────
+echo [+] Detected GPU(s):
+python -c "from fluxrt.utils.scan_hardware import scan_hardware; import json; print(json.dumps(scan_hardware()['gpu'], indent=2))"
+IF ERRORLEVEL 1 echo [!] Could not query the GPU — check the PyTorch install above.
 
 :: ── done ──────────────────────────────────────────────────────────────────────
 echo.

--- a/scripts/install.bat
+++ b/scripts/install.bat
@@ -1,7 +1,7 @@
 @echo off
 SETLOCAL EnableDelayedExpansion
 
-:: FluxRT installation script for Windows.
+:: FluxRT installation script for Windows (uv-based).
 :: Run from the repository root: scripts\install.bat
 
 :: ── sanity-check: running from repo root ──────────────────────────────────────
@@ -19,9 +19,11 @@ IF ERRORLEVEL 1 (
     exit /b 1
 )
 
-where conda >nul 2>&1
+where uv >nul 2>&1
 IF ERRORLEVEL 1 (
-    echo [ERROR] 'conda' is not installed. Install Miniconda or Anaconda first.
+    echo [ERROR] 'uv' is not installed.
+    echo         Install with: winget install astral-sh.uv
+    echo         Or:           powershell -c "irm https://astral.sh/uv/install.ps1 ^| iex"
     exit /b 1
 )
 
@@ -35,36 +37,21 @@ IF ERRORLEVEL 1 (
 
 echo [+] All prerequisites found.
 
-:: ── conda environment ─────────────────────────────────────────────────────────
-SET CONDA_ENV=fluxrt
-
-:: Locate conda base and load hooks so 'conda activate' works in this session.
-FOR /F "delims=" %%i IN ('conda info --base 2^>nul') DO SET CONDA_BASE=%%i
-IF "!CONDA_BASE!"=="" (
-    echo [ERROR] Cannot determine conda base directory.
-    exit /b 1
-)
-IF NOT EXIST "!CONDA_BASE!\Scripts\activate.bat" (
-    echo [ERROR] Cannot find conda activation script at !CONDA_BASE!\Scripts\activate.bat
-    exit /b 1
-)
-CALL "!CONDA_BASE!\Scripts\activate.bat" "!CONDA_BASE!"
-
-:: Check env by directory — more reliable than parsing 'conda env list'.
-IF EXIST "!CONDA_BASE!\envs\%CONDA_ENV%" (
-    echo [+] Conda environment '%CONDA_ENV%' already exists.
+:: ── virtual environment (uv, Python 3.12) ─────────────────────────────────────
+IF EXIST ".venv\Scripts\python.exe" (
+    echo [+] Virtual environment '.venv' already exists.
 ) ELSE (
-    echo [+] Creating conda environment '%CONDA_ENV%' (python=3.12^)...
-    cmd /c conda create -n %CONDA_ENV% python=3.12 pip -y
-    IF NOT EXIST "!CONDA_BASE!\envs\%CONDA_ENV%" (
-        echo [ERROR] Failed to create conda environment.
+    echo [+] Creating virtual environment '.venv' (Python 3.12^)...
+    uv venv --python 3.12
+    IF NOT EXIST ".venv\Scripts\python.exe" (
+        echo [ERROR] Failed to create virtual environment.
         exit /b 1
     )
 )
 
-CALL conda activate %CONDA_ENV%
+CALL ".venv\Scripts\activate.bat"
 IF ERRORLEVEL 1 (
-    echo [ERROR] Failed to activate conda environment '%CONDA_ENV%'.
+    echo [ERROR] Failed to activate virtual environment.
     exit /b 1
 )
 
@@ -76,7 +63,7 @@ IF ERRORLEVEL 1 (
 python -c "import torch, sys; sys.exit(0 if 'sm_120' in torch.cuda.get_arch_list() else 1)" >nul 2>&1
 IF ERRORLEVEL 1 (
     echo [+] Installing PyTorch with CUDA 12.8 / Blackwell sm_120 support...
-    pip install --upgrade torch torchvision --index-url https://download.pytorch.org/whl/cu128
+    uv pip install --upgrade torch torchvision --index-url https://download.pytorch.org/whl/cu128
     IF ERRORLEVEL 1 (
         echo [ERROR] Failed to install PyTorch.
         exit /b 1
@@ -90,7 +77,7 @@ IF ERRORLEVEL 1 (
 python -c "import diffusers" >nul 2>&1
 IF ERRORLEVEL 1 (
     echo [+] Installing Python requirements from requirements.txt...
-    pip install -r requirements.txt
+    uv pip install -r requirements.txt
     IF ERRORLEVEL 1 (
         echo [ERROR] Failed to install requirements.
         exit /b 1
@@ -104,7 +91,7 @@ IF ERRORLEVEL 1 (
 python -c "import triton" >nul 2>&1
 IF ERRORLEVEL 1 (
     echo [+] Installing triton-windows (required for model compilation^)...
-    pip install triton-windows
+    uv pip install triton-windows
     IF ERRORLEVEL 1 (
         echo [!] Warning: triton-windows installation failed.
         echo [!]          Model compilation may not work. Check compatibility at:
@@ -118,7 +105,7 @@ IF ERRORLEVEL 1 (
 python -c "import fluxrt" >nul 2>&1
 IF ERRORLEVEL 1 (
     echo [+] Installing fluxrt package in editable mode...
-    pip install -e .
+    uv pip install -e .
     IF ERRORLEVEL 1 (
         echo [ERROR] Failed to install fluxrt package.
         exit /b 1
@@ -247,7 +234,7 @@ echo [+] Installation complete.
 echo [!] Note: the GUI requires OBS to be installed for virtual webcam output.
 echo [!]       Download from https://obsproject.com/download
 echo.
-echo [+] Activate the environment and start:  conda activate %CONDA_ENV%
+echo [+] Activate the environment and start:  .venv\Scripts\activate
 echo [+] Then run, for example:               python scripts\run_gradio_demo.py
 
 ENDLOCAL

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,12 +41,16 @@ fi
 
 conda activate "$CONDA_ENV"
 
-# ── PyTorch ───────────────────────────────────────────────────────────────────
-if python -c "import torch" 2>/dev/null; then
-    log "PyTorch is already installed."
+# ── PyTorch (CUDA 12.8 / Blackwell sm_120 for RTX 50-series) ──────────────────
+# Check the build actually carries sm_120 kernels, not just that torch imports.
+# A cu128 wheel lists sm_120 regardless of the local GPU and also covers the
+# RTX 4090 (sm_89); a CPU or pre-cu128 torch fails on a 5090 ("sm_120 not
+# supported"). --upgrade replaces such a build in place.
+if python -c "import torch, sys; sys.exit(0 if 'sm_120' in torch.cuda.get_arch_list() else 1)" 2>/dev/null; then
+    log "PyTorch with CUDA 12.8 (Blackwell sm_120) already installed."
 else
-    log "Installing PyTorch with CUDA 12.8 support..."
-    pip install torch torchvision --index-url https://download.pytorch.org/whl/cu128
+    log "Installing PyTorch with CUDA 12.8 / Blackwell sm_120 support..."
+    pip install --upgrade torch torchvision --index-url https://download.pytorch.org/whl/cu128
 fi
 
 # ── Python requirements ───────────────────────────────────────────────────────
@@ -116,6 +120,24 @@ clone_or_resume \
     "https://huggingface.co/aydin99/FLUX.2-klein-4B-int8" \
     "FLUX.2-klein-4B-int8/diffusion_pytorch_model.safetensors" \
     "FLUX.2-klein-4B int8 model"
+
+# ── extension models (enabled per-config; small, downloaded by default) ───────
+clone_or_resume \
+    "taef2" \
+    "https://huggingface.co/madebyollin/taef2" \
+    "taef2/taef2.safetensors" \
+    "TAEF2 tiny-VAE model (extension)"
+
+clone_or_resume \
+    "FlowUpscaler" \
+    "https://huggingface.co/TensorForger/FlowUpscaler" \
+    "FlowUpscaler/flow_upscaler.safetensors" \
+    "Flow Upscaler model (extension)"
+
+# ── verify GPU detection ──────────────────────────────────────────────────────
+log "Detected GPU(s):"
+python -c "from fluxrt.utils.scan_hardware import scan_hardware; import json; print(json.dumps(scan_hardware()['gpu'], indent=2))" \
+    || warn "Could not query the GPU — check the PyTorch install above."
 
 # ── done ──────────────────────────────────────────────────────────────────────
 echo ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# FluxRT installation script.
+# FluxRT installation script (uv-based).
 # Run from the repository root: bash scripts/install.sh
 set -euo pipefail
 
@@ -20,26 +20,25 @@ die()  { echo -e "${RED}[ERROR]${NC} $*" >&2; exit 1; }
 # ── prerequisites ─────────────────────────────────────────────────────────────
 log "Checking prerequisites..."
 
-command -v git   &>/dev/null || die "'git' is not installed. Install it with your system package manager."
-command -v conda &>/dev/null || die "'conda' is not installed. Install Miniconda or Anaconda first."
-git lfs version  &>/dev/null || die "'git-lfs' is not installed. Install with: sudo apt install git-lfs  (or brew install git-lfs)"
+command -v git &>/dev/null || die "'git' is not installed. Install it with your system package manager."
+command -v uv  &>/dev/null || die "'uv' is not installed. Install with: curl -LsSf https://astral.sh/uv/install.sh | sh"
+git lfs version &>/dev/null || die "'git-lfs' is not installed. Install with: sudo apt install git-lfs  (or brew install git-lfs)"
 
 log "All prerequisites found."
 
-# ── conda environment ─────────────────────────────────────────────────────────
-CONDA_ENV="fluxrt"
-
-# shellcheck source=/dev/null
-source "$(conda info --base)/etc/profile.d/conda.sh"
-
-if conda env list | grep -qE "^${CONDA_ENV}[[:space:]]"; then
-    log "Conda environment '${CONDA_ENV}' already exists."
+# ── virtual environment (uv, Python 3.12) ─────────────────────────────────────
+VENV=".venv"
+if [ -x "$VENV/bin/python" ]; then
+    log "Virtual environment '${VENV}' already exists."
 else
-    log "Creating conda environment '${CONDA_ENV}' (python=3.12)..."
-    conda create -n "$CONDA_ENV" python=3.12 pip -y
+    log "Creating virtual environment '${VENV}' (Python 3.12)..."
+    uv venv --python 3.12 "$VENV"
 fi
 
-conda activate "$CONDA_ENV"
+# Target this venv for all subsequent python / uv pip calls without sourcing the
+# activate script (which can trip 'set -u').
+export VIRTUAL_ENV="$PWD/$VENV"
+export PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # ── PyTorch (CUDA 12.8 / Blackwell sm_120 for RTX 50-series) ──────────────────
 # Check the build actually carries sm_120 kernels, not just that torch imports.
@@ -50,7 +49,7 @@ if python -c "import torch, sys; sys.exit(0 if 'sm_120' in torch.cuda.get_arch_l
     log "PyTorch with CUDA 12.8 (Blackwell sm_120) already installed."
 else
     log "Installing PyTorch with CUDA 12.8 / Blackwell sm_120 support..."
-    pip install --upgrade torch torchvision --index-url https://download.pytorch.org/whl/cu128
+    uv pip install --upgrade torch torchvision --index-url https://download.pytorch.org/whl/cu128
 fi
 
 # ── Python requirements ───────────────────────────────────────────────────────
@@ -59,7 +58,7 @@ if python -c "import diffusers" 2>/dev/null; then
     log "Python requirements already installed."
 else
     log "Installing Python requirements from requirements.txt..."
-    pip install -r requirements.txt
+    uv pip install -r requirements.txt
 fi
 
 # ── fluxrt package ────────────────────────────────────────────────────────────
@@ -67,7 +66,7 @@ if python -c "import fluxrt" 2>/dev/null; then
     log "fluxrt package already installed."
 else
     log "Installing fluxrt package in editable mode..."
-    pip install -e .
+    uv pip install -e .
 fi
 
 # ── model downloads ───────────────────────────────────────────────────────────
@@ -142,5 +141,7 @@ python -c "from fluxrt.utils.scan_hardware import scan_hardware; import json; pr
 # ── done ──────────────────────────────────────────────────────────────────────
 echo ""
 log "${BOLD}Installation complete.${NC}"
-log "Activate the environment and start:  ${BOLD}conda activate ${CONDA_ENV}${NC}"
+warn "The GUI requires v4l2loopback (kernel module) for virtual-webcam output."
+warn "      Install it with your package manager, then: sudo modprobe v4l2loopback"
+log "Activate the environment and start:  ${BOLD}source ${VENV}/bin/activate${NC}"
 log "Then run, for example:               ${BOLD}python scripts/run_gradio_demo.py${NC}"

--- a/scripts/run_gui.py
+++ b/scripts/run_gui.py
@@ -284,8 +284,8 @@ QScrollBar::sub-line:horizontal {{
 # ── cross-thread signals ───────────────────────────────────────────────────────
 class _Signals(QObject):
     launch_capture = Signal(
-        object, int, str
-    )  # (cv2.VideoCapture | None, cam_idx, spout_name)
+        object, int, str, str
+    )  # (cv2.VideoCapture | None, cam_idx, spout_name, video_path)
     sp_error = Signal(str)
     camera_error = Signal()
     vcam_error = Signal(str)
@@ -331,6 +331,7 @@ class MainWindow(QMainWindow):
         self._spout_sender_stop = threading.Event()
 
         self._ref_full_path: str | None = None
+        self._video_path: str | None = None
 
         self._sig = _Signals()
         self._build_ui()
@@ -425,6 +426,29 @@ class MainWindow(QMainWindow):
         ctrl_layout.addWidget(spout_row, row, 1, 1, 2)
         self._spout_lbl.setVisible(_SPOUT_AVAILABLE)
         spout_row.setVisible(_SPOUT_AVAILABLE)
+        row += 1
+
+        # Video file input row (overrides camera when set)
+        ctrl_layout.addWidget(
+            QLabel("Video File:"),
+            row,
+            0,
+            Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter,
+        )
+        video_row = self._ctrl_row()
+        video_row_l = video_row.layout()
+        self._video_path_lbl = QLabel("(none — using camera)")
+        self._video_path_lbl.setObjectName("dim")
+        self._video_path_lbl.setMinimumWidth(260)
+        video_row_l.addWidget(self._video_path_lbl)
+        browse_video_btn = QPushButton("Browse")
+        browse_video_btn.clicked.connect(self._browse_video)
+        video_row_l.addWidget(browse_video_btn)
+        clear_video_btn = QPushButton("Clear")
+        clear_video_btn.clicked.connect(self._clear_video)
+        video_row_l.addWidget(clear_video_btn)
+        video_row_l.addStretch()
+        ctrl_layout.addWidget(video_row, row, 1, 1, 2)
         row += 1
 
         # Prompt row
@@ -627,6 +651,26 @@ class MainWindow(QMainWindow):
         except Exception as exc:
             log(f"Reference image load error: {exc}")
 
+    # ── video file input ───────────────────────────────────────────────────────
+
+    def _browse_video(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Select video file",
+            "",
+            "Videos (*.mp4 *.mov *.avi *.mkv *.webm);;All files (*.*)",
+        )
+        if not path:
+            return
+        self._video_path = path
+        self._video_path_lbl.setText(os.path.basename(path))
+        log(f"Video file selected: {path}")
+
+    def _clear_video(self) -> None:
+        self._video_path = None
+        self._video_path_lbl.setText("(none — using camera)")
+        log("Video file cleared — camera will be used")
+
     def _toggle_lip(self) -> None:
         self._lip_active = not self._lip_active
         self._lip_btn.setText(
@@ -646,10 +690,21 @@ class MainWindow(QMainWindow):
 
     def _begin_start(self) -> None:
         spout_name = self._spout_input_edit.text().strip() if _SPOUT_AVAILABLE else ""
+        video_path = self._video_path or ""
 
         if spout_name:
             # Spout input path — no camera needed
             cap, cam_idx = None, -1
+            self._cam_err_lbl.setText("")
+        elif video_path:
+            # Video file path — open VideoCapture on file
+            cap = cv2.VideoCapture(video_path)
+            if not cap.isOpened():
+                cap.release()
+                log(f"Start aborted: cannot open video {video_path}")
+                self.statusBar().showMessage(f"Cannot open video: {video_path}")
+                return
+            cam_idx = -1
             self._cam_err_lbl.setText("")
         else:
             # Camera path
@@ -675,14 +730,19 @@ class MainWindow(QMainWindow):
             prompt = self._prompt_edit.toPlainText()
             threading.Thread(
                 target=self._init_sp_thread,
-                args=(cap, cam_idx, prompt, spout_name),
+                args=(cap, cam_idx, prompt, spout_name, video_path),
                 daemon=True,
             ).start()
         else:
-            self._on_launch_capture(cap, cam_idx, spout_name)
+            self._on_launch_capture(cap, cam_idx, spout_name, video_path)
 
     def _init_sp_thread(
-        self, cap, cam_idx: int, prompt: str, spout_name: str = ""
+        self,
+        cap,
+        cam_idx: int,
+        prompt: str,
+        spout_name: str = "",
+        video_path: str = "",
     ) -> None:
         try:
             sp = StreamProcessor(self.config_path)
@@ -702,15 +762,17 @@ class MainWindow(QMainWindow):
                 self._apply_reference(self._ref_full_path)
             if self._lip_active:
                 sp.set_lip_transfer(True)
-            self._sig.launch_capture.emit(cap, cam_idx, spout_name)
+            self._sig.launch_capture.emit(cap, cam_idx, spout_name, video_path)
         except Exception as exc:
             log(f"StreamProcessor init error: {exc}")
             if cap is not None:
                 cap.release()
             self._sig.sp_error.emit(str(exc))
 
-    @Slot(object, int, str)
-    def _on_launch_capture(self, cap, cam_idx: int, spout_name: str = "") -> None:
+    @Slot(object, int, str, str)
+    def _on_launch_capture(
+        self, cap, cam_idx: int, spout_name: str = "", video_path: str = ""
+    ) -> None:
         self._sp_loading = False
         self._capture_stop.clear()
         self._running = True
@@ -719,6 +781,13 @@ class MainWindow(QMainWindow):
                 target=self._spout_input_loop, args=(spout_name,), daemon=True
             )
             status_msg = f"Running — Spout input: {spout_name}"
+        elif video_path:
+            self._capture_thread = threading.Thread(
+                target=self._video_capture_loop,
+                args=(cap, video_path),
+                daemon=True,
+            )
+            status_msg = f"Running — video file: {os.path.basename(video_path)}"
         else:
             self._capture_thread = threading.Thread(
                 target=self._capture_loop, args=(cap,), daemon=True
@@ -781,6 +850,63 @@ class MainWindow(QMainWindow):
                     self._latest_input = input_rgb
                     self._latest_output = output_rgb
                     self._latest_output_bgr = output_bgr
+        finally:
+            cap.release()
+
+    def _video_capture_loop(self, cap, video_path: str) -> None:
+        """
+        Reads from a video file, paces at the file's native FPS (default 30),
+        loops back to the start on EOF so the stream runs continuously.
+        """
+        h = self._resolution["height"]
+        w = self._resolution["width"]
+
+        src_fps = cap.get(cv2.CAP_PROP_FPS) or 0.0
+        if src_fps <= 0.0 or src_fps > 240.0:
+            src_fps = 30.0
+        frame_interval = 1.0 / src_fps
+        log(f"Video playback at {src_fps:.2f} fps — {video_path}")
+
+        next_t = time.time()
+        read_failures = 0
+        try:
+            while not self._capture_stop.is_set():
+                ok, frame = cap.read()
+                if not ok:
+                    # End of file — rewind and continue. A file with no
+                    # decodable frames would otherwise spin this loop at
+                    # full speed forever, so back off and eventually bail.
+                    read_failures += 1
+                    if read_failures > 10:
+                        log(f"Video unreadable after rewind, stopping: {video_path}")
+                        # Surface it so the UI resets (Start button, status) like
+                        # the camera path does — otherwise it's stuck on "Running".
+                        self._sig.camera_error.emit()
+                        break
+                    cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
+                    next_t = time.time()
+                    time.sleep(0.05)
+                    continue
+                read_failures = 0
+
+                cropped = crop_maximal_rectangle(frame, h, w)
+                with _sp_lock:
+                    self._input_tensor.copy_from(cropped)
+                    output_bgr = self._output_tensor.to_numpy()
+                input_rgb = cv2.cvtColor(cropped, cv2.COLOR_BGR2RGB)
+                output_rgb = cv2.cvtColor(output_bgr, cv2.COLOR_BGR2RGB)
+                with self._frame_lock:
+                    self._latest_input = input_rgb
+                    self._latest_output = output_rgb
+                    self._latest_output_bgr = output_bgr
+
+                next_t += frame_interval
+                sleep_for = next_t - time.time()
+                if sleep_for > 0:
+                    time.sleep(sleep_for)
+                else:
+                    # Pipeline slower than source FPS — reset clock to avoid drift.
+                    next_t = time.time()
         finally:
             cap.release()
 

--- a/scripts/run_webrtc.py
+++ b/scripts/run_webrtc.py
@@ -27,7 +27,6 @@ import itertools
 import json
 import logging
 import os
-import signal
 import threading
 import time
 from typing import Optional
@@ -56,6 +55,7 @@ QWEN_EDIT_TEMPLATE = os.path.join(WORKFLOWS_DIR, "qwen_edit_2509.api.json")
 
 from fluxrt import StreamProcessor
 from fluxrt.utils import crop_maximal_rectangle
+from fluxrt.webrtc.input_ownership import InputOwnership, consume_peer_input
 
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
@@ -96,16 +96,12 @@ ref_version: int = 0
 # peers keep draining their tracks (aiortc decodes inbound RTP regardless),
 # and the oldest waiter takes over when the current steerer disconnects.
 # When a peer owns the input, the local camera producer thread pauses.
-input_owner_pc: Optional[RTCPeerConnection] = None
-input_owner_lock = threading.Lock()
-peer_input_active = threading.Event()
-# False under --no-server-camera: there is no local producer, so the input
-# handoff must not pretend a "server camera" resumes when peers leave.
-has_server_camera: bool = True
-# seq -> pc for every peer with a live video track; min(seq) is next in line.
-input_waiters: dict[int, RTCPeerConnection] = {}
-# Connection order, assigned per /offer — defines who "first connected" is.
-_peer_seq = itertools.count()
+# The input-steering state machine (owner / waiters / active flag / seq counter)
+# lives in InputOwnership so the ownership transitions and the recv-eviction
+# policy are unit-tested off-GPU (tests/webrtc/). has_server_camera is set from
+# --no-server-camera in main(); it gates whether the local camera resumes when
+# the last peer leaves.
+ownership = InputOwnership(has_server_camera=True)
 
 # Strong refs to peer-input consumer tasks. asyncio only holds weak refs to
 # tasks, so without this a consumer can be GC'd mid-run; if its `finally`
@@ -235,7 +231,7 @@ def producer_loop(camera_index: int) -> None:
     log.info("StreamProcessor ready, producing frames from local camera.")
 
     while not producer_stop.is_set():
-        if peer_input_active.is_set():
+        if ownership.is_active():
             # A peer is driving input — skip local camera frames.
             time.sleep(0.05)
             continue
@@ -253,123 +249,31 @@ def producer_loop(camera_index: int) -> None:
 
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Per-peer input consumer — pulls VideoFrames from a remote track and feeds
-# them into the pipeline. The oldest-connected peer (lowest seq) steers;
-# the rest drain their tracks in view-only mode and the oldest waiter takes
-# over when the steerer disconnects.
+# Per-peer input consumer lives in fluxrt.webrtc.input_ownership.consume_peer_input
+# (unit-tested off-GPU). Here we only supply the frame sink (decode + pipeline
+# drive, offloaded to an executor) and the role-broadcast hook. The recv-eviction
+# POLICY — never evict a live owner on a frame gap; only drop a never-connected
+# waiter — also lives there. (c855950 regressed by evicting healthy owners on a
+# blind 5s timeout, which froze output under --no-server-camera.)
 # ──────────────────────────────────────────────────────────────────────────────
-async def consume_peer_input(track, pc: RTCPeerConnection, seq: int) -> None:
-    global input_owner_pc
+async def _frame_sink(frame) -> None:
+    """Owner-pump sink: offload decode (to_ndarray) + the pipeline write/read to
+    an executor so the asyncio event loop never blocks."""
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, _decode_and_push, frame)
 
-    def _try_claim() -> bool:
-        global input_owner_pc
-        with input_owner_lock:
-            if input_owner_pc is pc:
-                return True
-            if input_owner_pc is None and input_waiters and seq == min(input_waiters):
-                input_owner_pc = pc
-                peer_input_active.set()
-                return True
-            return False
 
-    with input_owner_lock:
-        input_waiters[seq] = pc
-
-    try:
-        # Wait for ownership. Frames must be drained meanwhile: aiortc
-        # decodes inbound RTP into an unbounded per-track queue whether or
-        # not recv() is called, so an idle view-only track grows memory.
-        was_waiting = False
-        while not _try_claim():
-            if not was_waiting:
-                was_waiting = True
-                log.info("Peer %x (seq %d) waiting — view-only", id(pc), seq)
-            try:
-                # Bounded: a track that registered but never delivers frames
-                # (ICE stuck / muted / media stall on a reconnect) must NOT park
-                # here forever — that pins this seq at the head of input_waiters
-                # and keeps peer_input_active set, freezing output. On timeout,
-                # bail so the finally pops this seq and a live peer can claim.
-                await asyncio.wait_for(track.recv(), timeout=5.0)
-            except asyncio.TimeoutError:
-                log.info("Waiting peer %x (seq %d) stalled — evicting", id(pc), seq)
-                return
-            except MediaStreamError:
-                return
-            except Exception as exc:
-                log.warning("Waiting peer track recv error: %s", exc)
-                return
-
-        log.info("Peer %x (seq %d) now drives input", id(pc), seq)
+def _input_notify(event: str, pc, outcome=None) -> None:
+    """Role broadcasts for consume_peer_input ownership transitions."""
+    if event == "claimed":
         broadcast_ctrl("input:peer")
         send_to_pc(pc, "input:you")
-        await _pump_owner_frames(track, pc)
-    finally:
-        with input_owner_lock:
-            input_waiters.pop(seq, None)
-            if input_owner_pc is pc:
-                input_owner_pc = None
-                log.info("Peer %x (seq %d) released input", id(pc), seq)
-            # If another waiter is in line it claims ownership on its next
-            # recv() and re-broadcasts input:peer; keep peer_input_active set
-            # so the server camera doesn't flicker in during the handoff.
-            if input_owner_pc is None and not input_waiters and peer_input_active.is_set():
-                peer_input_active.clear()
-                if has_server_camera:
-                    broadcast_ctrl("input:server")
-                    log.info("No peer inputs left — server camera resumes")
-                else:
-                    log.info("No peer inputs left — no server camera; output holds the last frame")
-
-
-async def _pump_owner_frames(track, pc: RTCPeerConnection) -> None:
-    loop = asyncio.get_running_loop()
-
-    # Drain-to-latest: the reader task always overwrites `latest`, the
-    # processing loop pushes only the newest frame. Without this, a pipeline
-    # slower than the peer's camera lets decoded frames accumulate in the
-    # track queue — round-trip lag grows without bound (and so does memory).
-    latest: list = [None]
-    new_frame = asyncio.Event()
-    stopped = asyncio.Event()
-
-    async def _reader():
-        try:
-            while True:
-                # Bounded so a silent-but-not-ended owner track (reconnect with
-                # ICE consent still alive) can't park the reader forever and pin
-                # ownership. TimeoutError falls through to the `except Exception`
-                # arm below → finally sets `stopped` → pump exits → ownership is
-                # released and the server camera / next waiter takes over.
-                latest[0] = await asyncio.wait_for(track.recv(), timeout=5.0)
-                new_frame.set()
-        except asyncio.TimeoutError:
-            # Deliberate eviction, not an error: owner stopped delivering frames
-            # for 5s. Fall through to finally → release input (don't log as error).
-            log.info("Owner %x stalled (no frames for 5s) — releasing input", id(pc))
-        except MediaStreamError:
-            pass
-        except Exception as exc:
-            log.warning("Peer track recv error: %s", exc)
-        finally:
-            stopped.set()
-            new_frame.set()  # wake the processing loop so it can exit
-
-    reader = asyncio.ensure_future(_reader())
-    try:
-        while not (stopped.is_set() and latest[0] is None):
-            await new_frame.wait()
-            new_frame.clear()
-            frame, latest[0] = latest[0], None
-            if frame is None:
-                continue
-            # Decode + pipeline write/read are blocking/CPU-bound — offload the
-            # whole thing (including to_ndarray) so the event loop never stalls.
-            await loop.run_in_executor(None, _decode_and_push, frame)
-    finally:
-        reader.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await reader
+    elif event == "released" and outcome is not None and outcome.became_idle:
+        if outcome.server_camera_resumes:
+            broadcast_ctrl("input:server")
+            log.info("No peer inputs left — server camera resumes")
+        else:
+            log.info("No peer inputs left — output holds the last frame")
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -426,16 +330,16 @@ async def _graceful_cleanup() -> None:
     log.info("Shutting down — stopping producer, peers, pipeline...")
     producer_stop.set()
 
-    # Hard-deadline watchdog. uvicorn routes Ctrl+C here via the lifespan
-    # shutdown; if any teardown step wedges (a D-state CUDA child, a stuck
-    # transport), guarantee the whole process group — server AND subprocesses —
-    # dies instead of hanging forever (e.g. in multiprocessing's no-timeout
-    # atexit join). killpg, not os._exit, so a child is never orphaned.
+    # Hard-deadline backstop. On Ctrl+C the spawned children also receive SIGINT
+    # (shared process group) and die immediately, and reap_process detaches any
+    # SIGKILL survivor from multiprocessing._children — so the normal path exits
+    # fast. This timer only fires if a teardown step itself wedges; os._exit
+    # bypasses the atexit no-timeout child join. (No killpg: no blast radius onto
+    # the operator's shell when the server isn't its own process-group leader.)
     def _hard_exit():
-        with contextlib.suppress(Exception):
-            os.killpg(os.getpgrp(), signal.SIGKILL)
+        os._exit(1)
 
-    watchdog = threading.Timer(30.0, _hard_exit)
+    watchdog = threading.Timer(15.0, _hard_exit)
     watchdog.daemon = True
     watchdog.start()
     try:
@@ -511,8 +415,6 @@ async def offer(request: Request):
 
     pc = RTCPeerConnection(_rtc_config())
     pcs.add(pc)
-    # Connection order decides who steers the input (lowest live seq wins).
-    seq = next(_peer_seq)
     # Channels opened by this PC — pruned from the broadcast set when the
     # connection dies, since the channel "close" event may never fire then.
     # Also reachable via the pc for targeted role messages (send_to_pc).
@@ -541,11 +443,15 @@ async def offer(request: Request):
     def _on_track(track):
         log.info("Inbound track from peer: kind=%s id=%s", track.kind, track.id)
         if track.kind == "video":
-            task = asyncio.ensure_future(consume_peer_input(track, pc, seq))
+            task = asyncio.ensure_future(
+                consume_peer_input(
+                    track, pc, ownership, _frame_sink, notify=_input_notify, log=log
+                )
+            )
             peer_input_tasks.add(task)
             task.add_done_callback(peer_input_tasks.discard)
-            # Let _on_state cancel this consumer on disconnect (recv() may never
-            # raise if the receiver never started — see _on_state).
+            # Let _on_state cancel this consumer on disconnect (the pump blocks on
+            # recv() — death is detected via connectionState, not a frame gap).
             pc._fluxrt_consume_task = task
 
     @pc.on("datachannel")
@@ -572,11 +478,10 @@ async def offer(request: Request):
         # Input-source role sync. The DataChannel usually opens after the
         # video track was claimed, so the targeted input:you from the claim
         # can be missed — resend it here.
-        if peer_input_active.is_set():
+        if ownership.is_active():
             safe_send(channel, "input:peer")
-            with input_owner_lock:
-                if input_owner_pc is pc:
-                    safe_send(channel, "input:you")
+            if ownership.owner_is(pc):
+                safe_send(channel, "input:you")
 
         @channel.on("close")
         def _on_close():
@@ -1206,12 +1111,12 @@ async def _health():
         "reference_version": ref_version,
         "input_source": (
             "peer"
-            if peer_input_active.is_set()
+            if ownership.is_active()
             else "server"
-            if has_server_camera
+            if ownership.has_server_camera
             else "none"
         ),
-        "input_waiters": len(input_waiters),
+        "input_waiters": ownership.num_waiters(),
         "lip_enabled": _lip_enabled(),
         "lip_active": lip_active,
         "prompt": current_prompt,
@@ -1388,7 +1293,7 @@ def main() -> None:
     sp.start()
 
     # Initialize parameter mirror from config + CLI overrides.
-    global current_prompt, current_seed, current_steps, has_server_camera
+    global current_prompt, current_seed, current_steps
     current_prompt = args.initial_prompt or sp.config.get("default_prompt", "")
     current_seed = int(sp.config.get("default_seed", 0))
     current_steps = int(sp.config.get("default_steps", 2))
@@ -1410,10 +1315,9 @@ def main() -> None:
 
     if args.no_server_camera:
         log.info("--no-server-camera: skipping local camera; waiting for peer input.")
-        # No local producer exists — leave peer_input_active clear so a peer sets
-        # it on claim, and /healthz honestly reports 'none' until then (instead
-        # of a phantom 'peer'/'server' source).
-        has_server_camera = False
+        # No local producer exists — /healthz reports 'none' until a peer claims,
+        # and the ownership object will not pretend a server camera resumes.
+        ownership.has_server_camera = False
     else:
         producer_thread = threading.Thread(
             target=producer_loop, args=(args.camera,), daemon=True

--- a/scripts/run_webrtc.py
+++ b/scripts/run_webrtc.py
@@ -417,6 +417,8 @@ def _rtc_config() -> RTCConfiguration:
 
 @app.post("/offer")
 async def offer(request: Request):
+    if sp is None:
+        raise HTTPException(status_code=503, detail="live pipeline not running (batch-only server)")
     body = await request.json()
     sdp = body.get("sdp")
     sdp_type = body.get("type")
@@ -1132,6 +1134,10 @@ async def _test_client():
 
 @app.get("/healthz")
 async def _health():
+    # Batch-only server has no live pipeline — return a minimal payload so a client
+    # polling /healthz (e.g. the clip header) doesn't error on the missing sp.
+    if sp is None:
+        return {"ready": False, "peers": 0, "batch_only": True}
     return {
         "ready": bool(sp and sp.is_ready()),
         "peers": len(pcs),
@@ -1194,6 +1200,11 @@ def _perf_metrics() -> dict:
 # completion, so an idle server pays nothing.
 # ──────────────────────────────────────────────────────────────────────────────
 _batch_enabled = os.environ.get("FLUXRT_BATCH_RENDER") == "1"
+# Batch-only: serve the batch API WITHOUT starting the live pipeline, so the batch
+# model is the only one on the GPU (the live model otherwise stays resident and a
+# second won't co-fit on a 24 GB card). Set via FLUXRT_BATCH_ONLY=1 or --batch-only.
+_batch_only = os.environ.get("FLUXRT_BATCH_ONLY") == "1"
+_batch_cfg_path: Optional[str] = None  # config to clone for batch when sp is absent
 _batch_manager = None
 
 
@@ -1233,13 +1244,24 @@ def _batch_vram_preflight() -> None:
         raise RuntimeError("stop the live stream to run a batch render (insufficient free VRAM for a second model)")
 
 
+def _batch_base_config() -> dict:
+    """Config the batch instance clones: the live processor's when it exists,
+    otherwise (batch-only) the config file loaded from disk."""
+    if sp is not None:
+        return sp.config
+    if _batch_cfg_path:
+        with open(_batch_cfg_path) as f:
+            return json.load(f)
+    raise RuntimeError("no config available for batch render")
+
+
 def _get_batch_manager():
     global _batch_manager
     if _batch_manager is None:
         from batch_render import BatchJobManager  # local import: pulls PyAV only when used
 
         _batch_manager = BatchJobManager(
-            base_config=sp.config,
+            base_config=_batch_base_config(),
             make_processor=lambda cfg: StreamProcessor(cfg),
             preflight=_batch_vram_preflight,
         )
@@ -1251,9 +1273,9 @@ from batch_routes import make_batch_router  # noqa: E402
 app.include_router(
     make_batch_router(
         get_manager=_get_batch_manager,
-        # Enabled only when opted in AND the live processor exists (its config is
-        # the base the batch instance clones).
-        is_enabled=lambda: _batch_enabled and sp is not None,
+        # Enabled when opted in with a live processor present, OR in batch-only mode
+        # (no live model — the batch model has the GPU to itself).
+        is_enabled=lambda: (_batch_enabled or _batch_only) and (sp is not None or _batch_only),
         default_prompt=lambda: current_prompt or (sp.config.get("default_prompt", "") if sp else ""),
     )
 )
@@ -1262,6 +1284,25 @@ app.include_router(
 # ──────────────────────────────────────────────────────────────────────────────
 # Entry point.
 # ──────────────────────────────────────────────────────────────────────────────
+def _run_server(args) -> None:
+    use_tls = bool(args.ssl_certfile and args.ssl_keyfile)
+    scheme = "https" if use_tls else "http"
+    log.info("Open %s://<this-host>:%d/ in a LAN browser", scheme, args.port)
+    if not use_tls:
+        log.warning(
+            "Running plain HTTP — browsers will block getUserMedia on non-"
+            "localhost origins. Pass --ssl-certfile + --ssl-keyfile for HTTPS."
+        )
+    uvicorn.run(
+        app,
+        host=args.host,
+        port=args.port,
+        log_level="info",
+        ssl_certfile=args.ssl_certfile,
+        ssl_keyfile=args.ssl_keyfile,
+    )
+
+
 def main() -> None:
     global sp, input_tensor, output_tensor, resolution, out_resolution
 
@@ -1280,6 +1321,12 @@ def main() -> None:
     parser.add_argument("--host", default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8765)
     parser.add_argument("--initial-prompt", default=None)
+    parser.add_argument(
+        "--batch-only",
+        action="store_true",
+        help="Serve ONLY the /batch/* render API; do not start the live pipeline so "
+        "the batch model has the GPU to itself. Implies batch render enabled.",
+    )
     parser.add_argument(
         "--interp",
         type=int,
@@ -1377,6 +1424,15 @@ def main() -> None:
     _load_saved_prompts()
     log.info("Loaded %d saved prompts from %s", len(saved_prompts), SAVED_PROMPTS_PATH)
 
+    global _batch_only, _batch_cfg_path
+    _batch_only = _batch_only or args.batch_only
+    if _batch_only:
+        # No live model — the batch instance (created per job) owns the GPU.
+        _batch_cfg_path = config_path
+        log.info("Batch-only mode: live pipeline NOT started; serving /batch/* only (config %s)", config_path)
+        _run_server(args)
+        return
+
     log.info("Loading StreamProcessor from %s", config_path)
     sp = StreamProcessor(config_path)
 
@@ -1432,23 +1488,7 @@ def main() -> None:
         )
         producer_thread.start()
 
-    use_tls = bool(args.ssl_certfile and args.ssl_keyfile)
-    scheme = "https" if use_tls else "http"
-    log.info("Open %s://<this-host>:%d/ in a LAN browser", scheme, args.port)
-    if not use_tls:
-        log.warning(
-            "Running plain HTTP — browsers will block getUserMedia on non-"
-            "localhost origins. Pass --ssl-certfile + --ssl-keyfile for HTTPS."
-        )
-
-    uvicorn.run(
-        app,
-        host=args.host,
-        port=args.port,
-        log_level="info",
-        ssl_certfile=args.ssl_certfile,
-        ssl_keyfile=args.ssl_keyfile,
-    )
+    _run_server(args)
 
 
 if __name__ == "__main__":

--- a/scripts/run_webrtc.py
+++ b/scripts/run_webrtc.py
@@ -1,0 +1,1379 @@
+"""
+FluxRT WebRTC streaming server.
+
+Streams the StreamProcessor output to any modern browser over WebRTC.
+Includes an inline minimal client (HTML+JS) served at `/`.
+
+Usage:
+    python scripts/run_webrtc.py
+    python scripts/run_webrtc.py --int8
+    python scripts/run_webrtc.py --config configs/config_with_reference.json --port 8765
+
+Then open `http://<linux-lan-ip>:8765/` on any LAN client.
+
+Control:
+    - Prompt / seed / steps updates: sent over a DataChannel.
+    - Reference image upload: HTTP POST /reference with raw image bytes.
+      Requires the active config to have `use_reference_image: true`
+      (e.g. `--config configs/config_with_reference.json`).
+"""
+
+import argparse
+import asyncio
+import contextlib
+import fractions
+import io
+import itertools
+import json
+import logging
+import os
+import threading
+import time
+from typing import Optional
+
+import av
+import cv2
+import httpx
+import numpy as np
+import uvicorn
+from aiortc import (
+    RTCConfiguration,
+    RTCIceServer,
+    RTCPeerConnection,
+    RTCSessionDescription,
+    VideoStreamTrack,
+)
+from aiortc.mediastreams import MediaStreamError
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse, Response
+from PIL import Image
+
+# ComfyUI API-format workflow templates patched + queued by /comfy/edit.
+WORKFLOWS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "comfy_workflows")
+QWEN_EDIT_TEMPLATE = os.path.join(WORKFLOWS_DIR, "qwen_edit_2509.api.json")
+
+from fluxrt import StreamProcessor
+from fluxrt.utils import crop_maximal_rectangle
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+log = logging.getLogger("fluxrt.webrtc")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Globals — populated in main() so module import stays cheap.
+# ──────────────────────────────────────────────────────────────────────────────
+sp: Optional[StreamProcessor] = None
+input_tensor = None
+output_tensor = None
+resolution = None
+out_resolution = None
+
+latest_rgb: Optional[np.ndarray] = None
+latest_lock = threading.Lock()
+producer_stop = threading.Event()
+
+# Serializes the actual pipeline drive (shared-tensor write + read). Both the
+# local producer thread and per-peer executor calls go through push_input_frame;
+# without this they can race during the camera->peer ownership handoff and drive
+# the pipeline from two threads at once.
+pipeline_lock = threading.Lock()
+
+# Cached reference image as PNG bytes for GET /reference preview.
+latest_reference_png: Optional[bytes] = None
+reference_lock = threading.Lock()
+
+pcs: set[RTCPeerConnection] = set()
+
+# Open control DataChannels for cross-client broadcast (e.g. reference image sync).
+ctrl_channels: set = set()
+ref_version: int = 0
+
+# Pipeline input ownership — the oldest-connected peer with a live video
+# track steers the input; every other peer just views the output. Waiting
+# peers keep draining their tracks (aiortc decodes inbound RTP regardless),
+# and the oldest waiter takes over when the current steerer disconnects.
+# When a peer owns the input, the local camera producer thread pauses.
+input_owner_pc: Optional[RTCPeerConnection] = None
+input_owner_lock = threading.Lock()
+peer_input_active = threading.Event()
+# False under --no-server-camera: there is no local producer, so the input
+# handoff must not pretend a "server camera" resumes when peers leave.
+has_server_camera: bool = True
+# seq -> pc for every peer with a live video track; min(seq) is next in line.
+input_waiters: dict[int, RTCPeerConnection] = {}
+# Connection order, assigned per /offer — defines who "first connected" is.
+_peer_seq = itertools.count()
+
+# Strong refs to peer-input consumer tasks. asyncio only holds weak refs to
+# tasks, so without this a consumer can be GC'd mid-run; if its `finally`
+# never executes, peer_input_active stays set and the producer never resumes.
+peer_input_tasks: set = set()
+
+MAX_REFERENCE_BYTES = 10 * 1024 * 1024  # 10 MB cap for uploaded reference images.
+
+# Configured ComfyUI servers (populated in main() from --comfy-server flags).
+# Maps display name → base URL (no trailing slash).
+comfy_servers: dict[str, str] = {}
+
+# Lip transfer (LivePortrait postprocessor) runtime state. The pipeline
+# always loads the model when `lip_transfer.enable` is true in config, but
+# the per-frame postprocess is gated by `set_lip_transfer(bool)`.
+lip_active: bool = False
+
+# Mirror the pipeline state so /healthz and late-joining peers can see it.
+# Updated from any path that changes the underlying value (API, DataChannel).
+current_prompt: str = ""
+current_seed: int = 0
+current_steps: int = 0
+
+# Liked prompts, persisted as JSON (no DB). Each entry carries the PROMPTING.md
+# live-testing scores: style / tracking / stability, 1-5, 0 = unrated.
+SAVED_PROMPTS_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "saved_prompts.json"
+)
+saved_prompts: list = []
+saved_prompts_lock = threading.Lock()
+
+
+def _load_saved_prompts() -> None:
+    global saved_prompts
+    try:
+        with open(SAVED_PROMPTS_PATH) as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            saved_prompts = [e for e in data if isinstance(e, dict) and e.get("prompt")]
+    except FileNotFoundError:
+        saved_prompts = []
+    except Exception as exc:
+        log.warning("Could not load %s: %s", SAVED_PROMPTS_PATH, exc)
+        saved_prompts = []
+
+
+def _write_saved_prompts() -> None:
+    """Atomic write — call with saved_prompts_lock held."""
+    tmp = SAVED_PROMPTS_PATH + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(saved_prompts, f, indent=2)
+    os.replace(tmp, SAVED_PROMPTS_PATH)
+
+
+def _clamp_rating(v) -> int:
+    try:
+        return max(0, min(5, int(v)))
+    except (TypeError, ValueError):
+        return 0
+
+
+def broadcast_ctrl(msg: str) -> None:
+    """Send a string message to every open control DataChannel."""
+    for ch in list(ctrl_channels):
+        safe_send(ch, msg)
+
+
+def safe_send(channel, msg: str) -> None:
+    """Send on a DataChannel, dropping it from the broadcast set on failure.
+    aiortc raises if the channel closed between the event and the send; that
+    must not propagate out of an event callback."""
+    try:
+        channel.send(msg)
+    except Exception as exc:
+        log.debug("ctrl send failed, dropping channel: %s", exc)
+        ctrl_channels.discard(channel)
+
+
+def send_to_pc(pc: RTCPeerConnection, msg: str) -> None:
+    """Send a control message only to the channels of one peer connection.
+    Used for role messages (input:you) that must not reach other clients."""
+    for ch in list(getattr(pc, "_fluxrt_channels", ()) or ()):
+        safe_send(ch, msg)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Shared frame push — runs the BGR input through the pipeline and updates
+# `latest_rgb` for any active video track to send out. Used by both the local
+# camera producer thread and per-peer track consumers.
+# ──────────────────────────────────────────────────────────────────────────────
+def push_input_frame(frame_bgr: np.ndarray) -> None:
+    global latest_rgb
+    h, w = resolution["height"], resolution["width"]
+    cropped = crop_maximal_rectangle(frame_bgr, h, w)
+    # Hold pipeline_lock across write+read so the producer thread and a peer's
+    # executor call can't interleave shared-tensor access during handoff.
+    with pipeline_lock:
+        input_tensor.copy_from(cropped)
+        out_bgr = output_tensor.to_numpy()
+    rgb = cv2.cvtColor(out_bgr, cv2.COLOR_BGR2RGB)
+    with latest_lock:
+        latest_rgb = rgb
+
+
+def _decode_and_push(frame) -> None:
+    """Decode an av.VideoFrame to BGR and run it through the pipeline. Kept
+    separate so the CPU-bound decode (to_ndarray) runs in an executor thread,
+    never on the asyncio event loop."""
+    push_input_frame(frame.to_ndarray(format="bgr24"))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Producer — local webcam frames. Pauses while a peer owns the input.
+# ──────────────────────────────────────────────────────────────────────────────
+def producer_loop(camera_index: int) -> None:
+    cap = cv2.VideoCapture(camera_index)
+    if not cap.isOpened():
+        log.error("Camera %d failed to open", camera_index)
+        return
+
+    log.info("Waiting for StreamProcessor to be ready...")
+    while not sp.is_ready():
+        if producer_stop.is_set():
+            cap.release()
+            return
+        time.sleep(0.1)
+    log.info("StreamProcessor ready, producing frames from local camera.")
+
+    while not producer_stop.is_set():
+        if peer_input_active.is_set():
+            # A peer is driving input — skip local camera frames.
+            time.sleep(0.05)
+            continue
+
+        ret, frame = cap.read()
+        if not ret:
+            log.warning("Camera read failed, retrying...")
+            time.sleep(0.05)
+            continue
+
+        push_input_frame(frame)
+
+    cap.release()
+    log.info("Producer stopped.")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Per-peer input consumer — pulls VideoFrames from a remote track and feeds
+# them into the pipeline. The oldest-connected peer (lowest seq) steers;
+# the rest drain their tracks in view-only mode and the oldest waiter takes
+# over when the steerer disconnects.
+# ──────────────────────────────────────────────────────────────────────────────
+async def consume_peer_input(track, pc: RTCPeerConnection, seq: int) -> None:
+    global input_owner_pc
+
+    def _try_claim() -> bool:
+        global input_owner_pc
+        with input_owner_lock:
+            if input_owner_pc is pc:
+                return True
+            if input_owner_pc is None and input_waiters and seq == min(input_waiters):
+                input_owner_pc = pc
+                peer_input_active.set()
+                return True
+            return False
+
+    with input_owner_lock:
+        input_waiters[seq] = pc
+
+    try:
+        # Wait for ownership. Frames must be drained meanwhile: aiortc
+        # decodes inbound RTP into an unbounded per-track queue whether or
+        # not recv() is called, so an idle view-only track grows memory.
+        was_waiting = False
+        while not _try_claim():
+            if not was_waiting:
+                was_waiting = True
+                log.info("Peer %x (seq %d) waiting — view-only", id(pc), seq)
+            try:
+                await track.recv()
+            except MediaStreamError:
+                return
+            except Exception as exc:
+                log.warning("Waiting peer track recv error: %s", exc)
+                return
+
+        log.info("Peer %x (seq %d) now drives input", id(pc), seq)
+        broadcast_ctrl("input:peer")
+        send_to_pc(pc, "input:you")
+        await _pump_owner_frames(track, pc)
+    finally:
+        with input_owner_lock:
+            input_waiters.pop(seq, None)
+            if input_owner_pc is pc:
+                input_owner_pc = None
+                log.info("Peer %x (seq %d) released input", id(pc), seq)
+            # If another waiter is in line it claims ownership on its next
+            # recv() and re-broadcasts input:peer; keep peer_input_active set
+            # so the server camera doesn't flicker in during the handoff.
+            if input_owner_pc is None and not input_waiters and peer_input_active.is_set():
+                peer_input_active.clear()
+                if has_server_camera:
+                    broadcast_ctrl("input:server")
+                    log.info("No peer inputs left — server camera resumes")
+                else:
+                    log.info("No peer inputs left — no server camera; output holds the last frame")
+
+
+async def _pump_owner_frames(track, pc: RTCPeerConnection) -> None:
+    loop = asyncio.get_running_loop()
+
+    # Drain-to-latest: the reader task always overwrites `latest`, the
+    # processing loop pushes only the newest frame. Without this, a pipeline
+    # slower than the peer's camera lets decoded frames accumulate in the
+    # track queue — round-trip lag grows without bound (and so does memory).
+    latest: list = [None]
+    new_frame = asyncio.Event()
+    stopped = asyncio.Event()
+
+    async def _reader():
+        try:
+            while True:
+                latest[0] = await track.recv()
+                new_frame.set()
+        except MediaStreamError:
+            pass
+        except Exception as exc:
+            log.warning("Peer track recv error: %s", exc)
+        finally:
+            stopped.set()
+            new_frame.set()  # wake the processing loop so it can exit
+
+    reader = asyncio.ensure_future(_reader())
+    try:
+        while not (stopped.is_set() and latest[0] is None):
+            await new_frame.wait()
+            new_frame.clear()
+            frame, latest[0] = latest[0], None
+            if frame is None:
+                continue
+            # Decode + pipeline write/read are blocking/CPU-bound — offload the
+            # whole thing (including to_ndarray) so the event loop never stalls.
+            await loop.run_in_executor(None, _decode_and_push, frame)
+    finally:
+        reader.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await reader
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# WebRTC video track — emits latest_rgb at a fixed frame rate.
+# ──────────────────────────────────────────────────────────────────────────────
+class FluxRTTrack(VideoStreamTrack):
+    """Yields the latest FluxRT output frame as `av.VideoFrame`s at `fps` Hz."""
+
+    kind = "video"
+
+    def __init__(self, fps: int = 30):
+        super().__init__()
+        self.fps = fps
+        self._t0 = time.time()
+        self._n = 0
+        # Output frames are at the (possibly upscaled) output resolution.
+        h, w = out_resolution["height"], out_resolution["width"]
+        self._blank = np.zeros((h, w, 3), dtype=np.uint8)
+
+    async def recv(self) -> av.VideoFrame:
+        # Pace ourselves; aiortc will pull frames as fast as recv() returns.
+        self._n += 1
+        target_t = self._t0 + self._n / self.fps
+        delay = target_t - time.time()
+        if delay > 0:
+            await asyncio.sleep(delay)
+        else:
+            # Behind schedule — skip ahead so we don't accumulate debt.
+            self._t0 = time.time() - self._n / self.fps
+
+        with latest_lock:
+            rgb = latest_rgb if latest_rgb is not None else self._blank
+
+        frame = av.VideoFrame.from_ndarray(rgb, format="rgb24")
+        frame.pts = self._n
+        frame.time_base = fractions.Fraction(1, self.fps)
+        return frame
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# FastAPI signaling app.
+# ──────────────────────────────────────────────────────────────────────────────
+_cleanup_done = threading.Event()
+
+
+async def _graceful_cleanup() -> None:
+    """Idempotent teardown: stop producer, close peers, stop the pipeline
+    (which now joins/terminates its subprocesses with timeouts). Safe to call
+    from the lifespan shutdown and from a signal handler."""
+    if _cleanup_done.is_set():
+        return
+    _cleanup_done.set()
+
+    log.info("Shutting down — stopping producer, peers, pipeline...")
+    producer_stop.set()
+
+    # Close all peer connections (best-effort, bounded).
+    for pc in list(pcs):
+        with contextlib.suppress(Exception):
+            await pc.close()
+    pcs.clear()
+
+    # sp.stop() does blocking joins; run it off the event loop so a wedged
+    # subprocess can't stall the loop while it escalates to terminate/kill.
+    if sp is not None:
+        loop = asyncio.get_running_loop()
+        with contextlib.suppress(Exception):
+            await loop.run_in_executor(None, sp.stop)
+    log.info("Shutdown complete.")
+
+
+@contextlib.asynccontextmanager
+async def _lifespan(app: FastAPI):
+    yield
+    await _graceful_cleanup()
+
+
+app = FastAPI(lifespan=_lifespan)
+
+# Cross-origin: the web client can run anywhere now (a local `vite dev`, a static
+# host) and connect to this backend directly. Allow its origin(s) — set
+# FLUXRT_CORS_ORIGINS (comma-separated) to lock down; default "*" (no credentials
+# are used, so "*" is valid).
+_cors_origins = [o.strip() for o in os.environ.get("FLUXRT_CORS_ORIGINS", "*").split(",") if o.strip()]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_cors_origins or ["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+def _rtc_config() -> RTCConfiguration:
+    """ICE servers for NAT traversal so a remote client can reach this backend.
+    STUN by default; add TURN via FLUXRT_TURN_URL (+ _USER/_PASS) when the backend
+    is behind NAT — host candidates alone aren't reachable across networks."""
+    servers = [RTCIceServer(urls=os.environ.get("FLUXRT_STUN", "stun:stun.l.google.com:19302"))]
+    turn = os.environ.get("FLUXRT_TURN_URL")
+    if turn:
+        servers.append(
+            RTCIceServer(
+                urls=turn,
+                username=os.environ.get("FLUXRT_TURN_USER"),
+                credential=os.environ.get("FLUXRT_TURN_PASS"),
+            )
+        )
+    return RTCConfiguration(iceServers=servers)
+
+
+@app.post("/offer")
+async def offer(request: Request):
+    body = await request.json()
+    sdp = body.get("sdp")
+    sdp_type = body.get("type")
+    if not sdp or not sdp_type:
+        raise HTTPException(status_code=400, detail="offer requires 'sdp' and 'type'")
+    offer_sdp = RTCSessionDescription(sdp=sdp, type=sdp_type)
+
+    pc = RTCPeerConnection(_rtc_config())
+    pcs.add(pc)
+    # Connection order decides who steers the input (lowest live seq wins).
+    seq = next(_peer_seq)
+    # Channels opened by this PC — pruned from the broadcast set when the
+    # connection dies, since the channel "close" event may never fire then.
+    # Also reachable via the pc for targeted role messages (send_to_pc).
+    pc_channels: set = set()
+    pc._fluxrt_channels = pc_channels
+
+    @pc.on("connectionstatechange")
+    async def _on_state():
+        log.info("PC state: %s", pc.connectionState)
+        if pc.connectionState in ("failed", "closed", "disconnected"):
+            await pc.close()
+            pcs.discard(pc)
+            ctrl_channels.difference_update(pc_channels)
+            pc_channels.clear()
+
+    @pc.on("track")
+    def _on_track(track):
+        log.info("Inbound track from peer: kind=%s id=%s", track.kind, track.id)
+        if track.kind == "video":
+            task = asyncio.ensure_future(consume_peer_input(track, pc, seq))
+            peer_input_tasks.add(task)
+            task.add_done_callback(peer_input_tasks.discard)
+
+    @pc.on("datachannel")
+    def _on_dc(channel):
+        log.info("DataChannel opened: %s", channel.label)
+        ctrl_channels.add(channel)
+        pc_channels.add(channel)
+
+        # Send the current reference version to a fresh peer so it can
+        # decide whether to refresh its preview.
+        if latest_reference_png is not None:
+            safe_send(channel, f"ref:set:{ref_version}")
+
+        # Sync lip transfer state on connect.
+        if _lip_enabled():
+            safe_send(channel, "lip:on" if lip_active else "lip:off")
+
+        # Send current pipeline parameter snapshot to a fresh peer.
+        if current_prompt:
+            safe_send(channel, f"state:prompt:{current_prompt}")
+        safe_send(channel, f"state:seed:{current_seed}")
+        safe_send(channel, f"state:steps:{current_steps}")
+
+        # Input-source role sync. The DataChannel usually opens after the
+        # video track was claimed, so the targeted input:you from the claim
+        # can be missed — resend it here.
+        if peer_input_active.is_set():
+            safe_send(channel, "input:peer")
+            with input_owner_lock:
+                if input_owner_pc is pc:
+                    safe_send(channel, "input:you")
+
+        @channel.on("close")
+        def _on_close():
+            ctrl_channels.discard(channel)
+            log.info("DataChannel closed: %s", channel.label)
+
+        @channel.on("message")
+        def _on_msg(msg):
+            if not isinstance(msg, str):
+                return
+            global current_prompt, current_seed, current_steps
+            if msg.startswith("prompt-travel:"):
+                # Wire format (ctrlProtocol.ts): "prompt-travel:<frames>:<mode>:<text>".
+                # text may contain colons, so peel off exactly the two leading
+                # fields with maxsplit=2. Reject anything that doesn't match the
+                # contract (same frames>=1 / mode checks as POST /prompt-travel)
+                # rather than silently treating the prefix as prompt text.
+                parts = msg[len("prompt-travel:"):].split(":", 2)
+                if (
+                    len(parts) == 3
+                    and parts[0].isdigit()
+                    and int(parts[0]) >= 1
+                    and parts[1] in ("slerp", "lerp")
+                    and parts[2].strip()
+                ):
+                    frames, mode = int(parts[0]), parts[1]
+                    new_prompt = parts[2].strip()
+                    log.info(
+                        "Prompt travel: %r (frames=%d, mode=%s)",
+                        new_prompt,
+                        frames,
+                        mode,
+                    )
+                    current_prompt = new_prompt
+                    sp.start_prompt_travel(new_prompt, frames=frames, mode=mode)
+                    safe_send(channel, "ack:prompt")
+                    broadcast_ctrl(f"state:prompt:{new_prompt}")
+                else:
+                    safe_send(channel, "err:prompt-travel")
+            elif msg.startswith("prompt:"):
+                new_prompt = msg[len("prompt:"):].strip()
+                if new_prompt:
+                    log.info("Prompt update: %r", new_prompt)
+                    current_prompt = new_prompt
+                    sp.set_prompt(new_prompt)
+                    safe_send(channel, "ack:prompt")
+                    broadcast_ctrl(f"state:prompt:{new_prompt}")
+            elif msg.startswith("seed:"):
+                try:
+                    seed = int(msg[len("seed:"):])
+                    current_seed = seed
+                    sp.set_seed(seed)
+                    safe_send(channel, f"ack:seed:{seed}")
+                    broadcast_ctrl(f"state:seed:{seed}")
+                except ValueError:
+                    safe_send(channel, "err:seed")
+            elif msg.startswith("steps:"):
+                try:
+                    steps = int(msg[len("steps:"):])
+                    if steps < 1 or steps > 8:
+                        raise ValueError("steps out of range")
+                    current_steps = steps
+                    sp.set_steps(steps)
+                    safe_send(channel, f"ack:steps:{steps}")
+                    broadcast_ctrl(f"state:steps:{steps}")
+                except ValueError:
+                    safe_send(channel, "err:steps")
+
+    pc.addTrack(FluxRTTrack(fps=30))
+
+    await pc.setRemoteDescription(offer_sdp)
+    answer = await pc.createAnswer()
+    await pc.setLocalDescription(answer)
+
+    return JSONResponse(
+        {"sdp": pc.localDescription.sdp, "type": pc.localDescription.type}
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Reference image upload — requires `use_reference_image: true` in config.
+# Accepts raw image bytes (PNG / JPEG / WebP) as the request body.
+# Browser posts with `Content-Type: application/octet-stream` (or any).
+# ──────────────────────────────────────────────────────────────────────────────
+def _reference_enabled() -> bool:
+    return bool(sp and sp.config.get("use_reference_image", False))
+
+
+def _lip_enabled() -> bool:
+    """Whether lip transfer is configured + the LivePortrait model loaded."""
+    if not sp:
+        return False
+    return bool(sp.config.get("lip_transfer", {}).get("enable", False))
+
+
+@app.post("/prompt")
+async def post_prompt(request: Request):
+    """Set the generation prompt.
+    Body: JSON {"prompt": "..."} OR raw text/plain.
+    Query: ?prompt=... (URL-encoded) as a third option."""
+    if not sp:
+        raise HTTPException(status_code=503, detail="StreamProcessor not ready")
+
+    prompt: str | None = None
+    q = request.query_params.get("prompt")
+    if q is not None:
+        prompt = q
+    else:
+        ctype = (request.headers.get("content-type") or "").lower()
+        if "application/json" in ctype:
+            try:
+                payload = await request.json()
+                prompt = payload.get("prompt") if isinstance(payload, dict) else None
+            except Exception as exc:
+                raise HTTPException(status_code=400, detail=f"Bad JSON: {exc}")
+        else:
+            prompt = (await request.body()).decode("utf-8", errors="replace")
+
+    if not prompt or not prompt.strip():
+        raise HTTPException(status_code=400, detail="Empty prompt")
+
+    prompt = prompt.strip()
+    global current_prompt
+    current_prompt = prompt
+    sp.set_prompt(prompt)
+    log.info("Prompt set via API: %r", prompt)
+    broadcast_ctrl(f"state:prompt:{prompt}")
+    return JSONResponse({"ok": True, "prompt": prompt})
+
+
+@app.post("/prompt-travel")
+async def post_prompt_travel(request: Request):
+    """Smoothly morph from the current prompt to a target prompt.
+    Body: JSON {"prompt": "...", "frames": 48, "mode": "slerp"} OR raw
+    text/plain (the target prompt, with default frames/mode).
+    Query: ?prompt=...&frames=...&mode=... as an alternative."""
+    if not sp:
+        raise HTTPException(status_code=503, detail="StreamProcessor not ready")
+
+    prompt: str | None = None
+    frames_raw = 48
+    mode = "slerp"
+
+    q = request.query_params.get("prompt")
+    if q is not None:
+        prompt = q
+        frames_raw = request.query_params.get("frames", frames_raw)
+        mode = request.query_params.get("mode", mode)
+    else:
+        ctype = (request.headers.get("content-type") or "").lower()
+        if "application/json" in ctype:
+            try:
+                payload = await request.json()
+            except Exception as exc:
+                raise HTTPException(status_code=400, detail=f"Bad JSON: {exc}")
+            if not isinstance(payload, dict):
+                raise HTTPException(status_code=400, detail="Expected JSON object")
+            prompt = payload.get("prompt")
+            frames_raw = payload.get("frames", frames_raw)
+            mode = payload.get("mode", mode)
+        else:
+            prompt = (await request.body()).decode("utf-8", errors="replace")
+
+    if not prompt or not prompt.strip():
+        raise HTTPException(status_code=400, detail="Empty prompt")
+    try:
+        frames = int(frames_raw)
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=400, detail="frames must be an integer")
+    if frames < 1:
+        raise HTTPException(status_code=400, detail="frames must be >= 1")
+    if mode not in ("slerp", "lerp"):
+        raise HTTPException(status_code=400, detail="mode must be 'slerp' or 'lerp'")
+
+    prompt = prompt.strip()
+    global current_prompt
+    current_prompt = prompt
+    sp.start_prompt_travel(prompt, frames=frames, mode=mode)
+    log.info("Prompt travel via API: %r (frames=%d, mode=%s)", prompt, frames, mode)
+    broadcast_ctrl(f"state:prompt:{prompt}")
+    return JSONResponse(
+        {"ok": True, "prompt": prompt, "frames": frames, "mode": mode}
+    )
+
+
+@app.post("/seed")
+async def post_seed(request: Request):
+    raw = request.query_params.get("value")
+    if raw is None:
+        try:
+            body = await request.json()
+            raw = body.get("value") if isinstance(body, dict) else None
+        except Exception:
+            raw = None
+    if raw is None:
+        raise HTTPException(status_code=400, detail="Missing ?value= (int)")
+    try:
+        seed = int(raw)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=400, detail=f"Not an int: {raw!r}")
+
+    global current_seed
+    current_seed = seed
+    sp.set_seed(seed)
+    log.info("Seed set via API: %d", seed)
+    broadcast_ctrl(f"state:seed:{seed}")
+    return JSONResponse({"ok": True, "seed": seed})
+
+
+@app.post("/steps")
+async def post_steps(request: Request):
+    raw = request.query_params.get("value")
+    if raw is None:
+        try:
+            body = await request.json()
+            raw = body.get("value") if isinstance(body, dict) else None
+        except Exception:
+            raw = None
+    if raw is None:
+        raise HTTPException(status_code=400, detail="Missing ?value= (int)")
+    try:
+        steps = int(raw)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=400, detail=f"Not an int: {raw!r}")
+    if steps < 1 or steps > 8:
+        raise HTTPException(status_code=400, detail="steps must be 1..8")
+
+    global current_steps
+    current_steps = steps
+    sp.set_steps(steps)
+    log.info("Steps set via API: %d", steps)
+    broadcast_ctrl(f"state:steps:{steps}")
+    return JSONResponse({"ok": True, "steps": steps})
+
+
+@app.post("/lip-transfer")
+async def post_lip_transfer(request: Request):
+    """Toggle LivePortrait lip transfer on/off.
+    Query: ?on=true|false (also accepts 1/0, yes/no)."""
+    if not _lip_enabled():
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Lip transfer not enabled in config. Restart with a config "
+                "containing lip_transfer.enable = true and the LivePortrait "
+                "directory present."
+            ),
+        )
+    raw = request.query_params.get("on", "").strip().lower()
+    if raw in ("1", "true", "yes", "on"):
+        on = True
+    elif raw in ("0", "false", "no", "off"):
+        on = False
+    else:
+        raise HTTPException(status_code=400, detail="?on= must be true/false")
+
+    global lip_active
+    lip_active = on
+    sp.set_lip_transfer(on)
+    log.info("Lip transfer: %s", "on" if on else "off")
+    broadcast_ctrl("lip:on" if on else "lip:off")
+    return JSONResponse({"ok": True, "lip_active": on})
+
+
+def _apply_reference_bytes(body: bytes, source_label: str) -> dict:
+    """Decode image bytes, set as reference, cache preview, bump version,
+    broadcast. Returns the JSON-shaped result dict. Raises HTTPException
+    on decode failure. Used by both /reference upload and /comfy/pull."""
+    try:
+        img = Image.open(io.BytesIO(body)).convert("RGB")
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"Decode error: {exc}")
+
+    rgb = np.array(img)
+    sp.set_reference_image(rgb)
+
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    global latest_reference_png, ref_version
+    with reference_lock:
+        latest_reference_png = buf.getvalue()
+        ref_version += 1
+        version = ref_version
+
+    log.info(
+        "Reference image set from %s: %dx%d (%d bytes, v%d)",
+        source_label, *rgb.shape[1::-1], len(body), version,
+    )
+    broadcast_ctrl(f"ref:set:{version}")
+
+    return {
+        "ok": True,
+        "size": [int(rgb.shape[1]), int(rgb.shape[0])],
+        "bytes": len(body),
+        "version": version,
+        "source": source_label,
+    }
+
+
+@app.post("/reference")
+async def post_reference(request: Request):
+    if not _reference_enabled():
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Reference image conditioning is disabled. "
+                "Restart with --config configs/config_with_reference.json"
+            ),
+        )
+
+    body = await request.body()
+    if not body:
+        raise HTTPException(status_code=400, detail="Empty body")
+    if len(body) > MAX_REFERENCE_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Image too large (>{MAX_REFERENCE_BYTES // (1024 * 1024)} MB)",
+        )
+
+    return JSONResponse(_apply_reference_bytes(body, "upload"))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# ComfyUI integration — pull latest output image from a configured server
+# and use it as the reference image. See the SKILL.md in
+# `~/Downloads/qwen-edit-test/` for the canonical comfy endpoints.
+# ──────────────────────────────────────────────────────────────────────────────
+@app.get("/comfy/servers")
+async def list_comfy_servers():
+    return {
+        "servers": [{"name": n, "url": u} for n, u in comfy_servers.items()],
+    }
+
+
+@app.post("/comfy/pull")
+async def pull_comfy(request: Request):
+    if not _reference_enabled():
+        raise HTTPException(status_code=400, detail="Reference image disabled")
+
+    name = request.query_params.get("server", "")
+    if not name or name not in comfy_servers:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown comfy server: {name!r}. "
+            f"Known: {list(comfy_servers.keys())}",
+        )
+    base = comfy_servers[name].rstrip("/")
+
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            hr = await client.get(f"{base}/history", params={"max_items": 20})
+            hr.raise_for_status()
+            history = hr.json()
+
+            # `history` is dict insertion-ordered; newest entries last.
+            chosen = None
+            for prompt_id, entry in reversed(list(history.items())):
+                outputs = entry.get("outputs", {}) or {}
+                for node_id, out in outputs.items():
+                    for image in out.get("images", []) or []:
+                        if image.get("type") != "output":
+                            continue
+                        chosen = (prompt_id, node_id, image)
+                        break
+                    if chosen:
+                        break
+                if chosen:
+                    break
+
+            if not chosen:
+                raise HTTPException(
+                    status_code=404,
+                    detail="No output images in recent comfy history",
+                )
+
+            prompt_id, node_id, image = chosen
+            params = {
+                "filename": image["filename"],
+                "type": image["type"],
+                "subfolder": image.get("subfolder", ""),
+            }
+            vr = await client.get(f"{base}/view", params=params)
+            vr.raise_for_status()
+            body = vr.content
+
+    except httpx.HTTPError as exc:
+        log.warning("Comfy pull HTTP error: %s", exc)
+        raise HTTPException(status_code=502, detail=f"Comfy server error: {exc}")
+
+    label = f"comfy:{name}:{image['filename']}"
+    result = _apply_reference_bytes(body, label)
+    result["prompt_id"] = prompt_id
+    result["node_id"] = node_id
+    result["filename"] = image["filename"]
+    return JSONResponse(result)
+
+
+@app.post("/comfy/edit")
+async def comfy_edit(request: Request):
+    """Snap an image (raw bytes body), run it through the Qwen-Image-Edit
+    2509 workflow on the selected comfy server, wait for the result, and
+    install it as the reference image.
+    Query: ?server=NAME&prompt=... (prompt falls back to the live prompt)."""
+    if not _reference_enabled():
+        raise HTTPException(status_code=400, detail="Reference image disabled")
+
+    name = request.query_params.get("server", "")
+    if not name or name not in comfy_servers:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown comfy server: {name!r}. Known: {list(comfy_servers.keys())}",
+        )
+    base = comfy_servers[name].rstrip("/")
+
+    prompt_text = request.query_params.get("prompt") or current_prompt or "enhance this person"
+
+    body = await request.body()
+    if not body:
+        raise HTTPException(status_code=400, detail="Empty body")
+    if len(body) > MAX_REFERENCE_BYTES:
+        raise HTTPException(status_code=413, detail="Image too large")
+
+    try:
+        with open(QWEN_EDIT_TEMPLATE, "r") as f:
+            wf = json.load(f)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Workflow template error: {exc}")
+
+    # The patch targets specific node ids from the exported graph — fail clearly
+    # if the template was re-exported/renumbered rather than KeyError-ing mid-run
+    # (after the snap was already uploaded to the comfy server).
+    for node_id in ("78", "111", "3"):
+        if node_id not in wf or "inputs" not in wf[node_id]:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Workflow template missing node {node_id} — re-export qwen_edit_2509.api.json",
+            )
+
+    seed = int.from_bytes(os.urandom(4), "big")
+
+    try:
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            # 1. upload the snapped frame to the comfy input/ folder
+            files = {"image": ("fluxrt_snap.png", body, "image/png")}
+            ur = await client.post(
+                f"{base}/upload/image", files=files, data={"overwrite": "true"}
+            )
+            ur.raise_for_status()
+            up = ur.json()
+            uploaded_name = up["name"]
+
+            # 2. patch the workflow: input image, prompt, seed
+            wf["78"]["inputs"]["image"] = uploaded_name
+            wf["111"]["inputs"]["prompt"] = prompt_text
+            wf["3"]["inputs"]["seed"] = seed
+
+            # 3. queue it
+            pr = await client.post(f"{base}/prompt", json={"prompt": wf})
+            pr.raise_for_status()
+            prompt_id = pr.json()["prompt_id"]
+            log.info("Qwen edit queued on %s: prompt_id=%s seed=%d", name, prompt_id, seed)
+
+            # 4. poll history until the output image appears (~4-step, fast)
+            out_image = None
+            for _ in range(90):
+                await asyncio.sleep(1.0)
+                hr = await client.get(f"{base}/history/{prompt_id}")
+                if hr.status_code != 200:
+                    continue
+                hist = hr.json()
+                entry = hist.get(prompt_id)
+                if not entry:
+                    continue
+                for _node, out in (entry.get("outputs", {}) or {}).items():
+                    for img in out.get("images", []) or []:
+                        if img.get("type") == "output":
+                            out_image = img
+                            break
+                    if out_image:
+                        break
+                if out_image:
+                    break
+
+            if not out_image:
+                raise HTTPException(status_code=504, detail="Qwen edit timed out")
+
+            # 5. fetch the result
+            vr = await client.get(
+                f"{base}/view",
+                params={
+                    "filename": out_image["filename"],
+                    "type": out_image["type"],
+                    "subfolder": out_image.get("subfolder", ""),
+                },
+            )
+            vr.raise_for_status()
+            result_bytes = vr.content
+
+    except httpx.HTTPError as exc:
+        log.warning("Comfy edit HTTP error: %s", exc)
+        raise HTTPException(status_code=502, detail=f"Comfy server error: {exc}")
+
+    # 6. install the edited image as the reference
+    result = _apply_reference_bytes(result_bytes, f"qwen-edit:{name}:{out_image['filename']}")
+    result["prompt_id"] = prompt_id
+    result["filename"] = out_image["filename"]
+    return JSONResponse(result)
+
+
+@app.delete("/reference")
+async def delete_reference():
+    if not _reference_enabled():
+        raise HTTPException(status_code=400, detail="Reference image disabled")
+    sp.set_reference_image(None)
+    global latest_reference_png, ref_version
+    with reference_lock:
+        latest_reference_png = None
+        ref_version += 1
+        version = ref_version
+    log.info("Reference image cleared (v%d)", version)
+    broadcast_ctrl(f"ref:clear:{version}")
+    return JSONResponse({"ok": True, "cleared": True, "version": version})
+
+
+@app.get("/reference")
+async def get_reference():
+    with reference_lock:
+        png = latest_reference_png
+    if png is None:
+        raise HTTPException(status_code=404, detail="No reference image set")
+    return Response(content=png, media_type="image/png")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Saved prompts — like/rate prompts, shared across clients, JSON-file backed.
+# Ratings follow the PROMPTING.md scale: style / tracking / stability, 1-5.
+# ──────────────────────────────────────────────────────────────────────────────
+@app.get("/prompts")
+async def list_saved_prompts():
+    with saved_prompts_lock:
+        return {"prompts": list(saved_prompts)}
+
+
+@app.post("/prompts")
+async def save_saved_prompt(request: Request):
+    """Upsert a prompt. Body: JSON {"prompt": "...", "style": 0-5,
+    "tracking": 0-5, "stability": 0-5} — ratings optional, 0 = unrated."""
+    try:
+        payload = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"Bad JSON: {exc}")
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="Body must be a JSON object")
+
+    prompt = (payload.get("prompt") or "").strip()
+    if not prompt:
+        raise HTTPException(status_code=400, detail="Empty prompt")
+
+    entry = {
+        "prompt": prompt,
+        "style": _clamp_rating(payload.get("style")),
+        "tracking": _clamp_rating(payload.get("tracking")),
+        "stability": _clamp_rating(payload.get("stability")),
+    }
+    with saved_prompts_lock:
+        for e in saved_prompts:
+            if e["prompt"] == prompt:
+                e.update(entry)
+                break
+        else:
+            saved_prompts.append(entry)
+        _write_saved_prompts()
+        count = len(saved_prompts)
+
+    log.info("Prompt saved (%d/%d/%d): %r",
+             entry["style"], entry["tracking"], entry["stability"], prompt)
+    broadcast_ctrl("prompts:changed")
+    return JSONResponse({"ok": True, "count": count, "entry": entry})
+
+
+@app.delete("/prompts")
+async def delete_saved_prompt(request: Request):
+    prompt = (request.query_params.get("prompt") or "").strip()
+    if not prompt:
+        raise HTTPException(status_code=400, detail="Missing ?prompt=")
+    with saved_prompts_lock:
+        before = len(saved_prompts)
+        saved_prompts[:] = [e for e in saved_prompts if e["prompt"] != prompt]
+        removed = before - len(saved_prompts)
+        if removed:
+            _write_saved_prompts()
+    if not removed:
+        raise HTTPException(status_code=404, detail="Prompt not in saved list")
+    log.info("Prompt deleted: %r", prompt)
+    broadcast_ctrl("prompts:changed")
+    return JSONResponse({"ok": True, "count": before - removed})
+
+
+@app.get("/")
+async def _index():
+    # Backend-only now (the web client lives in the realtime-client repo and is
+    # hosted separately). Root is a liveness/identity ping; see /healthz for stats.
+    return JSONResponse({"service": "fluxrt-webrtc", "ok": True})
+
+
+@app.get("/healthz")
+async def _health():
+    return {
+        "ready": bool(sp and sp.is_ready()),
+        "peers": len(pcs),
+        "resolution": resolution,
+        "reference_enabled": _reference_enabled(),
+        "reference_set": latest_reference_png is not None,
+        "reference_version": ref_version,
+        "input_source": (
+            "peer"
+            if peer_input_active.is_set()
+            else "server"
+            if has_server_camera
+            else "none"
+        ),
+        "input_waiters": len(input_waiters),
+        "lip_enabled": _lip_enabled(),
+        "lip_active": lip_active,
+        "prompt": current_prompt,
+        "seed": current_seed,
+        "steps": current_steps,
+        **_perf_metrics(),
+    }
+
+
+def _perf_metrics() -> dict:
+    """Pipeline FPS + VRAM snapshot for /healthz polling."""
+    if not sp:
+        return {
+            "fps_pipeline": 0.0,
+            "fps_interpolated": 0.0,
+            "proc_time_ms": 0.0,
+            "vram_mb": 0,
+        }
+    pt = sp.get_last_processing_time() or 0.0
+    base = (1.0 / pt) if pt > 0 else 0.0
+    exp = int(sp.config.get("interpolation_exp", 0))
+    try:
+        vram_mb = int(sp.get_reserved_memory())
+    except Exception:
+        vram_mb = 0
+    return {
+        "fps_pipeline": round(base, 2),
+        "fps_interpolated": round(base * (2 ** exp), 2),
+        "proc_time_ms": round(pt * 1000.0, 2),
+        "vram_mb": vram_mb,
+    }
+
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Entry point.
+# ──────────────────────────────────────────────────────────────────────────────
+def main() -> None:
+    global sp, input_tensor, output_tensor, resolution, out_resolution
+
+    parser = argparse.ArgumentParser(description="FluxRT WebRTC server")
+    parser.add_argument("--config", default="configs/stream_processor_config.json")
+    parser.add_argument("--int8", action="store_true", help="Enable int8 quantization")
+    parser.add_argument(
+        "--tiny-vae", action="store_true", help="Enable TAEF2 tiny VAE (enable_tiny_vae)"
+    )
+    parser.add_argument(
+        "--flow-upscaler",
+        action="store_true",
+        help="Enable 2x latent flow upscaler (enable_flow_upscaler); pairs well with --tiny-vae",
+    )
+    parser.add_argument("--camera", type=int, default=0, help="cv2 camera index")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--initial-prompt", default=None)
+    parser.add_argument(
+        "--interp",
+        type=int,
+        default=None,
+        metavar="EXP",
+        help=(
+            "Override interpolation_exp from config. RIFE emits 2^EXP output "
+            "frames per generated frame (0=off, 1=2x, 2=4x, 3=8x). Boot-time "
+            "only — sizes the shared frame buffer, cannot change at runtime."
+        ),
+    )
+    parser.add_argument(
+        "--no-server-camera",
+        action="store_true",
+        help=(
+            "Do not open the local OpenCV camera. Pipeline input then comes "
+            "from the first WebRTC peer that sends a video track."
+        ),
+    )
+    parser.add_argument(
+        "--ssl-certfile",
+        default=None,
+        help="Path to TLS cert (enables HTTPS, required by browsers for "
+        "getUserMedia on non-localhost origins).",
+    )
+    parser.add_argument(
+        "--ssl-keyfile",
+        default=None,
+        help="Path to TLS private key. Use together with --ssl-certfile.",
+    )
+    parser.add_argument(
+        "--comfy-server",
+        action="append",
+        default=[],
+        metavar="NAME=URL",
+        help=(
+            "Register a ComfyUI server the client can pull reference images "
+            "from. Repeatable. Example: "
+            "--comfy-server A=http://comfy-host:12040"
+        ),
+    )
+    args = parser.parse_args()
+
+    # Populate comfy_servers dict. Servers come from --comfy-server flags, or
+    # fall back to the FLUXRT_COMFY_SERVERS env var (comma-separated NAME=URL
+    # entries, e.g. "A=http://host:12040,B=http://host:12041"). No addresses
+    # are baked into the source. If neither is set, no servers are registered.
+    raw_entries = args.comfy_server or [
+        e.strip()
+        for e in os.environ.get("FLUXRT_COMFY_SERVERS", "").split(",")
+        if e.strip()
+    ]
+    for entry in raw_entries:
+        name, _, url = entry.partition("=")
+        name = name.strip()
+        url = url.strip().rstrip("/")
+        if not name or not url:
+            log.warning("Ignoring bad --comfy-server entry: %r", entry)
+            continue
+        comfy_servers[name] = url
+    log.info("Configured comfy servers: %s", comfy_servers)
+
+    config_path = args.config
+
+    # Some flags must be baked into the config the StreamProcessor constructor
+    # reads (it sizes buffers / selects models from it in __init__), so collect
+    # any overrides and write them to a patched temp config the constructor uses.
+    if args.interp is not None and (args.interp < 0 or args.interp > 4):
+        parser.error("--interp must be in 0..4")
+    overrides: dict = {}
+    if args.interp is not None:
+        overrides["interpolation_exp"] = args.interp
+    if args.tiny_vae:
+        overrides["enable_tiny_vae"] = True
+    if args.flow_upscaler:
+        overrides["enable_flow_upscaler"] = True
+    if overrides:
+        import atexit
+        import json as _json
+        import tempfile
+
+        with open(args.config) as f:
+            cfg = _json.load(f)
+        cfg.update(overrides)
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", prefix="fluxrt_cfg_", delete=False
+        )
+        _json.dump(cfg, tmp)
+        tmp.close()
+        config_path = tmp.name
+        # Don't leave the patched temp config behind in /tmp on exit.
+        atexit.register(lambda p=config_path: os.path.exists(p) and os.unlink(p))
+        log.info("config overrides from flags: %s", overrides)
+
+    _load_saved_prompts()
+    log.info("Loaded %d saved prompts from %s", len(saved_prompts), SAVED_PROMPTS_PATH)
+
+    log.info("Loading StreamProcessor from %s", config_path)
+    sp = StreamProcessor(config_path)
+
+    # Lip transfer only loads under int8 — bf16 + LivePortrait exceeds the
+    # 4090's 24 GB. Mutate the in-memory config before sp.start() so the
+    # inference subprocess never instantiates the postprocessor.
+    # ModelInferenceSubprocess holds the same dict reference and the spawn
+    # pickle happens during sp.start(), so this propagates correctly.
+    lp_cfg = sp.config.get("lip_transfer")
+    if lp_cfg and lp_cfg.get("enable"):
+        if args.int8:
+            log.info("Lip transfer: enabled (int8 mode)")
+        else:
+            log.warning(
+                "Lip transfer disabled: bf16 mode + LivePortrait would exceed "
+                "24 GB VRAM. Re-run with --int8 to enable lipsync."
+            )
+            lp_cfg["enable"] = False
+
+    if args.int8:
+        sp.enable_quantization()
+    sp.start()
+
+    # Initialize parameter mirror from config + CLI overrides.
+    global current_prompt, current_seed, current_steps, has_server_camera
+    current_prompt = args.initial_prompt or sp.config.get("default_prompt", "")
+    current_seed = int(sp.config.get("default_seed", 0))
+    current_steps = int(sp.config.get("default_steps", 2))
+
+    if args.initial_prompt:
+        sp.set_prompt(args.initial_prompt)
+
+    input_tensor = sp.get_input_tensor()
+    output_tensor = sp.get_output_tensor()
+    resolution = sp.get_resolution()
+    out_resolution = sp.get_out_resolution()
+    log.info(
+        "Resolution: in %dx%d  out %dx%d",
+        resolution["width"],
+        resolution["height"],
+        out_resolution["width"],
+        out_resolution["height"],
+    )
+
+    if args.no_server_camera:
+        log.info("--no-server-camera: skipping local camera; waiting for peer input.")
+        # No local producer exists — leave peer_input_active clear so a peer sets
+        # it on claim, and /healthz honestly reports 'none' until then (instead
+        # of a phantom 'peer'/'server' source).
+        has_server_camera = False
+    else:
+        producer_thread = threading.Thread(
+            target=producer_loop, args=(args.camera,), daemon=True
+        )
+        producer_thread.start()
+
+    use_tls = bool(args.ssl_certfile and args.ssl_keyfile)
+    scheme = "https" if use_tls else "http"
+    log.info("Open %s://<this-host>:%d/ in a LAN browser", scheme, args.port)
+    if not use_tls:
+        log.warning(
+            "Running plain HTTP — browsers will block getUserMedia on non-"
+            "localhost origins. Pass --ssl-certfile + --ssl-keyfile for HTTPS."
+        )
+
+    uvicorn.run(
+        app,
+        host=args.host,
+        port=args.port,
+        log_level="info",
+        ssl_certfile=args.ssl_certfile,
+        ssl_keyfile=args.ssl_keyfile,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_webrtc.py
+++ b/scripts/run_webrtc.py
@@ -191,6 +191,23 @@ def send_to_pc(pc: RTCPeerConnection, msg: str) -> None:
         safe_send(ch, msg)
 
 
+def _drive_prompt(prompt: str) -> None:
+    """Apply a prompt to whichever processor is active: the live pipeline and/or a
+    running batch render (live steering). Both are no-ops when absent."""
+    if sp is not None:
+        sp.set_prompt(prompt)
+    if _batch_manager is not None:
+        _batch_manager.set_prompt(prompt)
+
+
+def _drive_prompt_travel(prompt: str, frames: int, mode: str) -> None:
+    """Like _drive_prompt but a slerp/lerp morph over `frames` generated frames."""
+    if sp is not None:
+        sp.start_prompt_travel(prompt, frames=frames, mode=mode)
+    if _batch_manager is not None:
+        _batch_manager.start_prompt_travel(prompt, frames=frames, mode=mode)
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Shared frame push — runs the BGR input through the pipeline and updates
 # `latest_rgb` for any active video track to send out. Used by both the local
@@ -529,7 +546,7 @@ async def offer(request: Request):
                         mode,
                     )
                     current_prompt = new_prompt
-                    sp.start_prompt_travel(new_prompt, frames=frames, mode=mode)
+                    _drive_prompt_travel(new_prompt, frames, mode)
                     safe_send(channel, "ack:prompt")
                     broadcast_ctrl(f"state:prompt:{new_prompt}")
                 else:
@@ -539,7 +556,7 @@ async def offer(request: Request):
                 if new_prompt:
                     log.info("Prompt update: %r", new_prompt)
                     current_prompt = new_prompt
-                    sp.set_prompt(new_prompt)
+                    _drive_prompt(new_prompt)
                     safe_send(channel, "ack:prompt")
                     broadcast_ctrl(f"state:prompt:{new_prompt}")
             elif msg.startswith("seed:"):
@@ -594,9 +611,10 @@ def _lip_enabled() -> bool:
 async def post_prompt(request: Request):
     """Set the generation prompt.
     Body: JSON {"prompt": "..."} OR raw text/plain.
-    Query: ?prompt=... (URL-encoded) as a third option."""
-    if not sp:
-        raise HTTPException(status_code=503, detail="StreamProcessor not ready")
+    Query: ?prompt=... (URL-encoded) as a third option.
+    Works against the live pipeline AND/OR a running batch render (live steering)."""
+    if sp is None and (_batch_manager is None or _batch_manager.active_job_id() is None):
+        raise HTTPException(status_code=503, detail="no live pipeline or batch render to set a prompt on")
 
     prompt: str | None = None
     q = request.query_params.get("prompt")
@@ -619,7 +637,7 @@ async def post_prompt(request: Request):
     prompt = prompt.strip()
     global current_prompt
     current_prompt = prompt
-    sp.set_prompt(prompt)
+    _drive_prompt(prompt)
     log.info("Prompt set via API: %r", prompt)
     broadcast_ctrl(f"state:prompt:{prompt}")
     return JSONResponse({"ok": True, "prompt": prompt})
@@ -630,9 +648,10 @@ async def post_prompt_travel(request: Request):
     """Smoothly morph from the current prompt to a target prompt.
     Body: JSON {"prompt": "...", "frames": 48, "mode": "slerp"} OR raw
     text/plain (the target prompt, with default frames/mode).
-    Query: ?prompt=...&frames=...&mode=... as an alternative."""
-    if not sp:
-        raise HTTPException(status_code=503, detail="StreamProcessor not ready")
+    Query: ?prompt=...&frames=...&mode=... as an alternative.
+    Works against the live pipeline AND/OR a running batch render (live steering)."""
+    if sp is None and (_batch_manager is None or _batch_manager.active_job_id() is None):
+        raise HTTPException(status_code=503, detail="no live pipeline or batch render to morph")
 
     prompt: str | None = None
     frames_raw = 48
@@ -672,7 +691,7 @@ async def post_prompt_travel(request: Request):
     prompt = prompt.strip()
     global current_prompt
     current_prompt = prompt
-    sp.start_prompt_travel(prompt, frames=frames, mode=mode)
+    _drive_prompt_travel(prompt, frames, mode)
     log.info("Prompt travel via API: %r (frames=%d, mode=%s)", prompt, frames, mode)
     broadcast_ctrl(f"state:prompt:{prompt}")
     return JSONResponse(

--- a/scripts/run_webrtc.py
+++ b/scripts/run_webrtc.py
@@ -56,6 +56,7 @@ QWEN_EDIT_TEMPLATE = os.path.join(WORKFLOWS_DIR, "qwen_edit_2509.api.json")
 from fluxrt import StreamProcessor
 from fluxrt.utils import crop_maximal_rectangle
 from fluxrt.webrtc.input_ownership import InputOwnership, consume_peer_input
+from fluxrt.webrtc.stats import connection_pool_stats
 
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
@@ -1105,6 +1106,10 @@ async def _health():
     return {
         "ready": bool(sp and sp.is_ready()),
         "peers": len(pcs),
+        # Active connection-pool breakdown (total / connected / per-state).
+        "connections": connection_pool_stats(
+            [getattr(pc, "connectionState", "unknown") for pc in list(pcs)]
+        ),
         "resolution": resolution,
         "reference_enabled": _reference_enabled(),
         "reference_set": latest_reference_png is not None,

--- a/scripts/run_webrtc.py
+++ b/scripts/run_webrtc.py
@@ -418,6 +418,13 @@ async def _graceful_cleanup() -> None:
             await pc.close()
     pcs.clear()
 
+    # Tear down any in-flight batch render: cancel + bounded-join its worker so the
+    # second model's subprocess isn't orphaned at exit. Off the loop (it blocks).
+    if _batch_manager is not None and _batch_manager.active_job_id() is not None:
+        loop = asyncio.get_running_loop()
+        with contextlib.suppress(Exception):
+            await loop.run_in_executor(None, _batch_manager.shutdown)
+
     # sp.stop() does blocking joins; run it off the event loop so a wedged
     # subprocess can't stall the loop while it escalates to terminate/kill.
     if sp is not None:
@@ -1216,6 +1223,65 @@ def _perf_metrics() -> dict:
         "vram_mb": vram_mb,
     }
 
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Batch frame-for-frame render (offline). A dedicated, parked StreamProcessor
+# renders a whole video 1:1 (scripts/batch_render.py + docs/batch-render-spec.md).
+# Gated behind an explicit opt-in: a second full FLUX.2 model does NOT co-fit with
+# the live stream on a 24 GB GPU, so the operator enables this only on a host with
+# the capacity. The batch StreamProcessor is created on submit and torn down on
+# completion, so an idle server pays nothing.
+# ──────────────────────────────────────────────────────────────────────────────
+_batch_enabled = os.environ.get("FLUXRT_BATCH_RENDER") == "1"
+_batch_manager = None
+
+
+def _batch_vram_preflight() -> None:
+    """Best-effort gate: refuse a batch job when a second full model is unlikely to
+    fit alongside the live one. Skips silently if VRAM can't be measured — the
+    FLUXRT_BATCH_RENDER opt-in remains the primary guard. Raises RuntimeError (→ 409)
+    when there isn't headroom."""
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return
+        free_mb = torch.cuda.mem_get_info()[0] // (1024 * 1024)
+    except Exception:
+        return  # cannot measure → rely on the operator opt-in
+    need_mb = 0
+    with contextlib.suppress(Exception):
+        if sp is not None:
+            need_mb = int(sp.get_reserved_memory())  # live model footprint ≈ batch model footprint
+    if need_mb and free_mb < need_mb * 1.1:
+        raise RuntimeError("stop the live stream to run a batch render (insufficient free VRAM for a second model)")
+
+
+def _get_batch_manager():
+    global _batch_manager
+    if _batch_manager is None:
+        from batch_render import BatchJobManager  # local import: pulls PyAV only when used
+
+        _batch_manager = BatchJobManager(
+            base_config=sp.config,
+            make_processor=lambda cfg: StreamProcessor(cfg),
+            preflight=_batch_vram_preflight,
+        )
+    return _batch_manager
+
+
+from batch_routes import make_batch_router  # noqa: E402
+
+app.include_router(
+    make_batch_router(
+        get_manager=_get_batch_manager,
+        # Enabled only when opted in AND the live processor exists (its config is
+        # the base the batch instance clones).
+        is_enabled=lambda: _batch_enabled and sp is not None,
+        default_prompt=lambda: current_prompt or (sp.config.get("default_prompt", "") if sp else ""),
+    )
+)
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/scripts/run_webrtc.py
+++ b/scripts/run_webrtc.py
@@ -1131,6 +1131,19 @@ async def _index():
     return JSONResponse({"service": "fluxrt-webrtc", "ok": True})
 
 
+@app.get("/test")
+async def _test_client():
+    """Minimal standalone WebRTC test client (same-origin), with an ICE
+    diagnostics panel — for comparing the FluxRT connection candidate-by-candidate
+    against the StreamDiffusion (sd-webrtc) client. Open http://<server>/test."""
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "webrtc_test_client.html")
+    try:
+        with open(path, encoding="utf-8") as f:
+            return Response(f.read(), media_type="text/html")
+    except OSError:
+        raise HTTPException(status_code=404, detail="webrtc_test_client.html not found")
+
+
 @app.get("/healthz")
 async def _health():
     return {

--- a/scripts/run_webrtc.py
+++ b/scripts/run_webrtc.py
@@ -27,6 +27,7 @@ import itertools
 import json
 import logging
 import os
+import signal
 import threading
 import time
 from typing import Optional
@@ -284,7 +285,15 @@ async def consume_peer_input(track, pc: RTCPeerConnection, seq: int) -> None:
                 was_waiting = True
                 log.info("Peer %x (seq %d) waiting — view-only", id(pc), seq)
             try:
-                await track.recv()
+                # Bounded: a track that registered but never delivers frames
+                # (ICE stuck / muted / media stall on a reconnect) must NOT park
+                # here forever — that pins this seq at the head of input_waiters
+                # and keeps peer_input_active set, freezing output. On timeout,
+                # bail so the finally pops this seq and a live peer can claim.
+                await asyncio.wait_for(track.recv(), timeout=5.0)
+            except asyncio.TimeoutError:
+                log.info("Waiting peer %x (seq %d) stalled — evicting", id(pc), seq)
+                return
             except MediaStreamError:
                 return
             except Exception as exc:
@@ -327,8 +336,17 @@ async def _pump_owner_frames(track, pc: RTCPeerConnection) -> None:
     async def _reader():
         try:
             while True:
-                latest[0] = await track.recv()
+                # Bounded so a silent-but-not-ended owner track (reconnect with
+                # ICE consent still alive) can't park the reader forever and pin
+                # ownership. TimeoutError falls through to the `except Exception`
+                # arm below → finally sets `stopped` → pump exits → ownership is
+                # released and the server camera / next waiter takes over.
+                latest[0] = await asyncio.wait_for(track.recv(), timeout=5.0)
                 new_frame.set()
+        except asyncio.TimeoutError:
+            # Deliberate eviction, not an error: owner stopped delivering frames
+            # for 5s. Fall through to finally → release input (don't log as error).
+            log.info("Owner %x stalled (no frames for 5s) — releasing input", id(pc))
         except MediaStreamError:
             pass
         except Exception as exc:
@@ -408,19 +426,40 @@ async def _graceful_cleanup() -> None:
     log.info("Shutting down — stopping producer, peers, pipeline...")
     producer_stop.set()
 
-    # Close all peer connections (best-effort, bounded).
-    for pc in list(pcs):
+    # Hard-deadline watchdog. uvicorn routes Ctrl+C here via the lifespan
+    # shutdown; if any teardown step wedges (a D-state CUDA child, a stuck
+    # transport), guarantee the whole process group — server AND subprocesses —
+    # dies instead of hanging forever (e.g. in multiprocessing's no-timeout
+    # atexit join). killpg, not os._exit, so a child is never orphaned.
+    def _hard_exit():
         with contextlib.suppress(Exception):
-            await pc.close()
-    pcs.clear()
+            os.killpg(os.getpgrp(), signal.SIGKILL)
 
-    # sp.stop() does blocking joins; run it off the event loop so a wedged
-    # subprocess can't stall the loop while it escalates to terminate/kill.
-    if sp is not None:
-        loop = asyncio.get_running_loop()
-        with contextlib.suppress(Exception):
-            await loop.run_in_executor(None, sp.stop)
-    log.info("Shutdown complete.")
+    watchdog = threading.Timer(30.0, _hard_exit)
+    watchdog.daemon = True
+    watchdog.start()
+    try:
+        # Close all peers concurrently and bounded: a half-open peer's
+        # pc.close() can await a transport teardown that never completes
+        # (contextlib.suppress does NOT bound a hang), which would otherwise
+        # block shutdown before sp.stop() ever runs.
+        async def _close(pc):
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(pc.close(), timeout=3.0)
+
+        if pcs:
+            await asyncio.gather(*[_close(pc) for pc in list(pcs)])
+        pcs.clear()
+
+        # sp.stop() does blocking joins; run it off the event loop so a wedged
+        # subprocess can't stall the loop while it escalates to terminate/kill.
+        if sp is not None:
+            loop = asyncio.get_running_loop()
+            with contextlib.suppress(Exception):
+                await loop.run_in_executor(None, sp.stop)
+        log.info("Shutdown complete.")
+    finally:
+        watchdog.cancel()
 
 
 @contextlib.asynccontextmanager
@@ -484,6 +523,15 @@ async def offer(request: Request):
     async def _on_state():
         log.info("PC state: %s", pc.connectionState)
         if pc.connectionState in ("failed", "closed", "disconnected"):
+            # Cancel the input consumer directly — do NOT rely solely on
+            # pc.close() ending the track to make recv() raise. aiortc's
+            # receiver.stop() is a no-op when the receiver never started (DTLS
+            # never connected on a failed reconnect), so the consumer's
+            # `await track.recv()` would never raise and the task would leak as
+            # a phantom waiter that pins peer_input_active and freezes output.
+            t = getattr(pc, "_fluxrt_consume_task", None)
+            if t is not None:
+                t.cancel()
             await pc.close()
             pcs.discard(pc)
             ctrl_channels.difference_update(pc_channels)
@@ -496,6 +544,9 @@ async def offer(request: Request):
             task = asyncio.ensure_future(consume_peer_input(track, pc, seq))
             peer_input_tasks.add(task)
             task.add_done_callback(peer_input_tasks.discard)
+            # Let _on_state cancel this consumer on disconnect (recv() may never
+            # raise if the receiver never started — see _on_state).
+            pc._fluxrt_consume_task = task
 
     @pc.on("datachannel")
     def _on_dc(channel):

--- a/scripts/run_webrtc.py
+++ b/scripts/run_webrtc.py
@@ -360,19 +360,18 @@ async def _graceful_cleanup() -> None:
             await asyncio.gather(*[_close(pc) for pc in list(pcs)])
         pcs.clear()
 
-        # Tear down any in-flight batch render: cancel + bounded-join its worker so
-        # the second model's subprocess isn't orphaned at exit. Off the loop (blocks).
+        # Tear down the live processor AND any in-flight batch render CONCURRENTLY
+        # (independent processes) so neither eats the other's slice of the 15s
+        # watchdog budget. Both do blocking joins → run off the event loop. The
+        # batch join is bounded short so the live reap keeps headroom.
+        loop = asyncio.get_running_loop()
+        teardowns = []
         if _batch_manager is not None and _batch_manager.active_job_id() is not None:
-            loop = asyncio.get_running_loop()
-            with contextlib.suppress(Exception):
-                await loop.run_in_executor(None, _batch_manager.shutdown)
-
-        # sp.stop() does blocking joins; run it off the event loop so a wedged
-        # subprocess can't stall the loop while it escalates to terminate/kill.
+            teardowns.append(loop.run_in_executor(None, lambda: _batch_manager.shutdown(4.0)))
         if sp is not None:
-            loop = asyncio.get_running_loop()
-            with contextlib.suppress(Exception):
-                await loop.run_in_executor(None, sp.stop)
+            teardowns.append(loop.run_in_executor(None, sp.stop))
+        if teardowns:
+            await asyncio.gather(*teardowns, return_exceptions=True)
         log.info("Shutdown complete.")
     finally:
         watchdog.cancel()
@@ -1198,18 +1197,33 @@ _batch_enabled = os.environ.get("FLUXRT_BATCH_RENDER") == "1"
 _batch_manager = None
 
 
+def _free_vram_mb() -> Optional[int]:
+    """Free VRAM (MB) of the most-free GPU via nvidia-smi, or None if unavailable.
+    Uses the CLI on purpose — importing torch / calling mem_get_info() here would
+    create a CUDA context in the web process and waste VRAM that the live model needs."""
+    import shutil
+    import subprocess
+
+    if shutil.which("nvidia-smi") is None:
+        return None
+    try:
+        out = subprocess.run(
+            ["nvidia-smi", "--query-gpu=memory.free", "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=3, check=True,
+        ).stdout
+    except Exception:
+        return None
+    vals = [int(x) for x in out.split() if x.strip().isdigit()]
+    return max(vals) if vals else None
+
+
 def _batch_vram_preflight() -> None:
     """Best-effort gate: refuse a batch job when a second full model is unlikely to
     fit alongside the live one. Skips silently if VRAM can't be measured — the
     FLUXRT_BATCH_RENDER opt-in remains the primary guard. Raises RuntimeError (→ 409)
     when there isn't headroom."""
-    try:
-        import torch
-
-        if not torch.cuda.is_available():
-            return
-        free_mb = torch.cuda.mem_get_info()[0] // (1024 * 1024)
-    except Exception:
+    free_mb = _free_vram_mb()
+    if free_mb is None:
         return  # cannot measure → rely on the operator opt-in
     need_mb = 0
     with contextlib.suppress(Exception):

--- a/scripts/run_webrtc.py
+++ b/scripts/run_webrtc.py
@@ -71,6 +71,9 @@ resolution = None
 out_resolution = None
 
 latest_rgb: Optional[np.ndarray] = None
+# Latest pipeline INPUT frame (cropped BGR), so a recvonly/listening client can
+# preview what's being sent in. Guarded by latest_lock alongside latest_rgb.
+latest_input_bgr: Optional[np.ndarray] = None
 latest_lock = threading.Lock()
 producer_stop = threading.Event()
 
@@ -196,7 +199,7 @@ def send_to_pc(pc: RTCPeerConnection, msg: str) -> None:
 # camera producer thread and per-peer track consumers.
 # ──────────────────────────────────────────────────────────────────────────────
 def push_input_frame(frame_bgr: np.ndarray) -> None:
-    global latest_rgb
+    global latest_rgb, latest_input_bgr
     h, w = resolution["height"], resolution["width"]
     cropped = crop_maximal_rectangle(frame_bgr, h, w)
     # Hold pipeline_lock across write+read so the producer thread and a peer's
@@ -207,6 +210,7 @@ def push_input_frame(frame_bgr: np.ndarray) -> None:
     rgb = cv2.cvtColor(out_bgr, cv2.COLOR_BGR2RGB)
     with latest_lock:
         latest_rgb = rgb
+        latest_input_bgr = cropped  # served to listeners via GET /input.jpg
 
 
 def _decode_and_push(frame) -> None:
@@ -1057,6 +1061,25 @@ async def get_reference():
     if png is None:
         raise HTTPException(status_code=404, detail="No reference image set")
     return Response(content=png, media_type="image/png")
+
+
+@app.get("/input.jpg")
+async def get_input_jpg():
+    # Current pipeline INPUT frame as JPEG — what's actually feeding the model
+    # (a peer's stream or the server camera). Lets a recvonly/listening client
+    # preview the input it isn't sending. 204 when nothing is driving input.
+    if peer_input_active.is_set() or has_server_camera:
+        with latest_lock:
+            frame = None if latest_input_bgr is None else latest_input_bgr.copy()
+        if frame is not None:
+            ok, buf = cv2.imencode(".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, 80])
+            if ok:
+                return Response(
+                    content=buf.tobytes(),
+                    media_type="image/jpeg",
+                    headers={"Cache-Control": "no-store"},
+                )
+    return Response(status_code=204)
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/scripts/run_webrtc.py
+++ b/scripts/run_webrtc.py
@@ -454,6 +454,12 @@ async def offer(request: Request):
     @pc.on("connectionstatechange")
     async def _on_state():
         log.info("PC state: %s", pc.connectionState)
+        # NOTE: aiortc's connectionState is only new/connecting/connected/failed/
+        # closed — it never emits "disconnected" (unlike the browser). "disconnected"
+        # is kept here as a harmless no-op guard; a dead owner whose pc lingers in
+        # "connected" until ICE consent expiry (~30s) is handed off far sooner by
+        # the frame-gap policy in consume_peer_input (owner_gap_should_release),
+        # not by this handler.
         if pc.connectionState in ("failed", "closed", "disconnected"):
             # Cancel the input consumer directly — do NOT rely solely on
             # pc.close() ending the track to make recv() raise. aiortc's

--- a/scripts/webrtc_test_client.html
+++ b/scripts/webrtc_test_client.html
@@ -19,10 +19,11 @@
  <label>server</label>
  <input id=server type=text style="width:300px" placeholder="same-origin — or http://host:port">
  <button onclick="reconnect()">connect</button>
+ <button id=modebtn onclick="toggleMode()">mode: listen 👂</button>
  <span style="color:#789;font-size:12px">cross-origin needs CORS + secure-context (flag for http)</span>
 </div>
 <div class=row>
- <div><div>camera (you)</div><video id=local autoplay muted playsinline></video></div>
+ <div><div id=locallabel>camera — off (listening)</div><video id=local autoplay muted playsinline></video></div>
  <div><div>FluxRT output</div><video id=remote autoplay playsinline></video></div>
 </div>
 
@@ -37,12 +38,21 @@
 
 <script>
 let pc, dc;
+// 'listen' = receive-only (no camera, just watch the FluxRT output — the default
+// the page boots into). 'publish' = also send the local camera as pipeline input.
+let mode = 'listen';
 const $=id=>document.getElementById(id), v=id=>$(id).value;
 const srv=()=>(($('server').value||'').trim().replace(/\/+$/,''));
 const S=p=>srv()+p;
 function send(m){ if(dc&&dc.readyState==='open') dc.send(m); }
 function reconnect(){ try{pc&&pc.close()}catch(_){} localStorage.setItem('fluxrt_server',srv());
   $('stat').textContent='connecting…'; start().catch(e=>{$('stat').textContent='error: '+e.message;console.error(e);}); }
+function setModeLabel(){
+  $('modebtn').textContent = 'mode: '+(mode==='publish'?'publish 🔴':'listen 👂');
+  $('locallabel').textContent = mode==='publish' ? 'camera (you)' : 'camera — off (listening)';
+}
+function toggleMode(){ mode = mode==='publish' ? 'listen' : 'publish';
+  localStorage.setItem('fluxrt_mode', mode); setModeLabel(); reconnect(); }
 
 // --- ICE diagnostics: this is the comparison surface vs sd-webrtc ---
 let iceLines=[];
@@ -71,9 +81,18 @@ async function start(){
   if(hz.seed!=null) $('seed').value=hz.seed;
   if(hz.steps!=null) $('steps').value=hz.steps;
 
-  const cam = await navigator.mediaDevices.getUserMedia(
-    {video:{width:{ideal:w},height:{ideal:h},frameRate:{ideal:30,max:30}},audio:false});
-  $('local').srcObject = cam;
+  // Listen mode (default): no camera — just receive the output. Publish mode:
+  // grab the local camera and feed it to the pipeline. The server always sends
+  // its FluxRTTrack regardless (POST /offer addTrack), so a recvonly client gets
+  // the output and simply contributes no input.
+  let cam = null;
+  if (mode === 'publish') {
+    cam = await navigator.mediaDevices.getUserMedia(
+      {video:{width:{ideal:w},height:{ideal:h},frameRate:{ideal:30,max:30}},audio:false});
+    $('local').srcObject = cam;
+  } else {
+    $('local').srcObject = null;
+  }
 
   // Negotiate on a LOCAL conn (race-safe — same fix as sd-webrtc).
   // Client-side STUN is LOAD-BEARING: without it the client gathers only mDNS
@@ -82,7 +101,8 @@ async function start(){
   // is why the standalone clients failed against the remote server.
   const conn = new RTCPeerConnection({ iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] });
   pc = conn;
-  conn.addTransceiver(cam.getVideoTracks()[0], {direction:'sendrecv', streams:[cam]});
+  if (cam) conn.addTransceiver(cam.getVideoTracks()[0], {direction:'sendrecv', streams:[cam]});
+  else     conn.addTransceiver('video', {direction:'recvonly'}); // listen: receive output only
   conn.ontrack = e => { $('remote').srcObject = e.streams[0];
     try{ e.receiver.jitterBufferTarget = 0; }catch(_){}
     try{ e.receiver.playoutDelayHint = 0; }catch(_){}
@@ -118,12 +138,15 @@ async function poll(){
       `resolution: ${hz.resolution?.width}x${hz.resolution?.height}\n`+
       `<span class="${live?'live':'dead'}">pipeline  : ${hz.fps_pipeline??'-'} fps   interp ${hz.fps_interpolated??'-'}   proc ${hz.proc_time_ms??'-'}ms   vram ${hz.vram_mb??'-'}MB</span>\n`+
       `prompt/seed/steps: ${hz.prompt} / ${hz.seed} / ${hz.steps}`;
-    $('stat').textContent = live ? 'connected · input live' : 'connected · NO INPUT';
+    $('stat').textContent = (mode==='publish'?'publish':'listen')+' · '+(live ? 'input live' : 'NO INPUT');
   }catch(e){ $('stat').textContent='poll error'; }
   setTimeout(poll, 1000);
 }
 
 const _q=new URLSearchParams(location.search);
 $('server').value = _q.get('server') || localStorage.getItem('fluxrt_server') || '';
+// Boot in listening mode by default (?mode=publish or a prior toggle overrides).
+mode = _q.get('mode') || localStorage.getItem('fluxrt_mode') || 'listen';
+setModeLabel();
 start().catch(e=>{ $('stat').textContent='error: '+e.message; console.error(e); });
 </script></body></html>

--- a/scripts/webrtc_test_client.html
+++ b/scripts/webrtc_test_client.html
@@ -1,0 +1,125 @@
+<!doctype html><html><head><meta charset=utf-8>
+<title>FluxRT WebRTC test</title>
+<style>
+ body{font-family:system-ui;background:#111;color:#eee;margin:0;padding:16px}
+ .row{display:flex;gap:16px;flex-wrap:wrap}
+ video{width:512px;max-width:46vw;background:#000;border-radius:8px}
+ .bar{margin:8px 0;display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+ .panel{margin-top:14px;max-width:560px;display:grid;grid-template-columns:120px 1fr auto;gap:8px 10px;align-items:center}
+ input[type=text],input[type=number]{font-size:14px;padding:6px;background:#222;color:#eee;border:1px solid #444;border-radius:5px}
+ button{font-size:13px;padding:6px 10px;background:#2a6cd4;color:#fff;border:0;border-radius:5px;cursor:pointer}
+ label{color:#9ab;font-size:13px}
+ #stat{margin-left:10px;font-size:13px}
+ #readout,#ice{margin-top:12px;font-size:12px;white-space:pre-wrap;font-family:ui-monospace,monospace}
+ #readout{color:#8ad}#ice{color:#cda;border-top:1px solid #333;padding-top:8px}
+ .live{color:#3f6}.dead{color:#f66}
+</style></head><body>
+<h3>FluxRT WebRTC test <span id=stat>idle</span></h3>
+<div class=bar>
+ <label>server</label>
+ <input id=server type=text style="width:300px" placeholder="same-origin — or http://host:port">
+ <button onclick="reconnect()">connect</button>
+ <span style="color:#789;font-size:12px">cross-origin needs CORS + secure-context (flag for http)</span>
+</div>
+<div class=row>
+ <div><div>camera (you)</div><video id=local autoplay muted playsinline></video></div>
+ <div><div>FluxRT output</div><video id=remote autoplay playsinline></video></div>
+</div>
+
+<div class=panel>
+ <label>prompt</label><input id=prompt type=text><button onclick="send('prompt:'+v('prompt'))">set</button>
+ <label>seed</label><input id=seed type=number value=0><button onclick="send('seed:'+v('seed'))">set</button>
+ <label>steps</label><input id=steps type=number value=2 min=1 max=8><button onclick="send('steps:'+v('steps'))">set</button>
+</div>
+
+<div id=readout>loading…</div>
+<div id=ice>ICE: —</div>
+
+<script>
+let pc, dc;
+const $=id=>document.getElementById(id), v=id=>$(id).value;
+const srv=()=>(($('server').value||'').trim().replace(/\/+$/,''));
+const S=p=>srv()+p;
+function send(m){ if(dc&&dc.readyState==='open') dc.send(m); }
+function reconnect(){ try{pc&&pc.close()}catch(_){} localStorage.setItem('fluxrt_server',srv());
+  $('stat').textContent='connecting…'; start().catch(e=>{$('stat').textContent='error: '+e.message;console.error(e);}); }
+
+// --- ICE diagnostics: this is the comparison surface vs sd-webrtc ---
+let iceLines=[];
+function ice(msg){ iceLines.push(msg); if(iceLines.length>40) iceLines.shift(); $('ice').textContent='ICE\n'+iceLines.join('\n'); }
+function shortCand(c){ // candidate string → "typ host 192.168.x udp"
+  const s=(c&&c.candidate)||''; const m=s.match(/candidate:\S+ \d+ (\S+) \d+ (\S+) (\d+) typ (\S+)/);
+  return m ? `typ ${m[4]} ${m[2]}:${m[3]} ${m[1].toLowerCase()}` : (s||'(end-of-candidates)');
+}
+async function logSelectedPair(conn){
+  try{ const stats=await conn.getStats();
+    let pair=null, loc={}, rem={};
+    stats.forEach(r=>{ if(r.type==='candidate-pair'&&(r.selected||r.nominated||r.state==='succeeded')) pair=r;
+      if(r.type==='local-candidate') loc[r.id]=r; if(r.type==='remote-candidate') rem[r.id]=r; });
+    if(pair){ const l=loc[pair.localCandidateId], r=rem[pair.remoteCandidateId];
+      ice(`SELECTED pair: ${l?l.candidateType+' '+(l.address||l.ip)+':'+l.port:''}  ↔  ${r?r.candidateType+' '+(r.address||r.ip)+':'+r.port:''}  (${pair.state})`);
+    } else ice('no selected candidate-pair yet');
+  }catch(e){ ice('getStats err: '+e.message); }
+}
+
+async function start(){
+  if(pc){ try{pc.close()}catch(_){} pc=null; }
+  iceLines=[]; ice('start');
+  const hz = await (await fetch(S('/healthz'))).json();
+  const w=hz.resolution?.width||512, h=hz.resolution?.height||512;
+  if(hz.prompt) $('prompt').value=hz.prompt;
+  if(hz.seed!=null) $('seed').value=hz.seed;
+  if(hz.steps!=null) $('steps').value=hz.steps;
+
+  const cam = await navigator.mediaDevices.getUserMedia(
+    {video:{width:{ideal:w},height:{ideal:h},frameRate:{ideal:30,max:30}},audio:false});
+  $('local').srcObject = cam;
+
+  // Negotiate on a LOCAL conn (race-safe — same fix as sd-webrtc).
+  const conn = new RTCPeerConnection();
+  pc = conn;
+  conn.addTransceiver(cam.getVideoTracks()[0], {direction:'sendrecv', streams:[cam]});
+  conn.ontrack = e => { $('remote').srcObject = e.streams[0];
+    try{ e.receiver.jitterBufferTarget = 0; }catch(_){}
+    try{ e.receiver.playoutDelayHint = 0; }catch(_){}
+  };
+  conn.onicecandidate = e => { if(e.candidate) ice('local  cand: '+shortCand(e.candidate)); else ice('local  gathering complete'); };
+  conn.oniceconnectionstatechange = () => { ice('ICE state: '+conn.iceConnectionState);
+    if(conn.iceConnectionState==='connected'||conn.iceConnectionState==='completed') logSelectedPair(conn); };
+  conn.onconnectionstatechange = () => ice('PC state: '+conn.connectionState);
+
+  dc = conn.createDataChannel('ctrl');
+  dc.onmessage = e => { const d=e.data||''; if(d.startsWith('state:')) {/* server state echoes */} };
+
+  const offer = await conn.createOffer(); await conn.setLocalDescription(offer);
+  await new Promise(r=>{ if(conn.iceGatheringState==='complete')return r();
+    const t=setTimeout(r,2000);
+    conn.onicegatheringstatechange=()=>{ if(conn.iceGatheringState==='complete'){clearTimeout(t);r();} }; });
+  const ans = await (await fetch(S('/offer'),{method:'POST',headers:{'content-type':'application/json'},
+    body:JSON.stringify({sdp:conn.localDescription.sdp,type:conn.localDescription.type})})).json();
+  if(pc!==conn || conn.signalingState!=='have-local-offer'){ try{conn.close()}catch(_){} return; }
+  await conn.setRemoteDescription(ans);
+  // The server's candidates arrive in the answer SDP — list them for comparison.
+  (ans.sdp||'').split('\n').filter(l=>l.startsWith('a=candidate')).forEach(l=>ice('server cand: '+shortCand({candidate:l.slice(2).trim()})));
+  $('stat').textContent='connected'; poll();
+}
+
+let prev=null, prevT=0;
+async function poll(){
+  try{
+    const hz = await (await fetch(S('/healthz'),{cache:'no-store'})).json();
+    const live = hz.input_source && hz.input_source!=='none';
+    $('readout').innerHTML =
+      `peers     : ${hz.peers}   input_source: ${hz.input_source}\n`+
+      `resolution: ${hz.resolution?.width}x${hz.resolution?.height}\n`+
+      `<span class="${live?'live':'dead'}">pipeline  : ${hz.fps_pipeline??'-'} fps   interp ${hz.fps_interpolated??'-'}   proc ${hz.proc_time_ms??'-'}ms   vram ${hz.vram_mb??'-'}MB</span>\n`+
+      `prompt/seed/steps: ${hz.prompt} / ${hz.seed} / ${hz.steps}`;
+    $('stat').textContent = live ? 'connected · input live' : 'connected · NO INPUT';
+  }catch(e){ $('stat').textContent='poll error'; }
+  setTimeout(poll, 1000);
+}
+
+const _q=new URLSearchParams(location.search);
+$('server').value = _q.get('server') || localStorage.getItem('fluxrt_server') || '';
+start().catch(e=>{ $('stat').textContent='error: '+e.message; console.error(e); });
+</script></body></html>

--- a/scripts/webrtc_test_client.html
+++ b/scripts/webrtc_test_client.html
@@ -3,7 +3,7 @@
 <style>
  body{font-family:system-ui;background:#111;color:#eee;margin:0;padding:16px}
  .row{display:flex;gap:16px;flex-wrap:wrap}
- video{width:512px;max-width:46vw;background:#000;border-radius:8px}
+ video,#inputimg{width:512px;max-width:46vw;background:#000;border-radius:8px}
  .bar{margin:8px 0;display:flex;gap:8px;align-items:center;flex-wrap:wrap}
  .panel{margin-top:14px;max-width:560px;display:grid;grid-template-columns:120px 1fr auto;gap:8px 10px;align-items:center}
  input[type=text],input[type=number]{font-size:14px;padding:6px;background:#222;color:#eee;border:1px solid #444;border-radius:5px}
@@ -23,7 +23,7 @@
  <span style="color:#789;font-size:12px">cross-origin needs CORS + secure-context (flag for http)</span>
 </div>
 <div class=row>
- <div><div id=locallabel>camera — off (listening)</div><video id=local autoplay muted playsinline></video></div>
+ <div><div id=locallabel>input — none (listening)</div><video id=local autoplay muted playsinline style="display:none"></video><img id=inputimg alt=""></div>
  <div><div>FluxRT output</div><video id=remote autoplay playsinline></video></div>
 </div>
 
@@ -48,11 +48,39 @@ function send(m){ if(dc&&dc.readyState==='open') dc.send(m); }
 function reconnect(){ try{pc&&pc.close()}catch(_){} localStorage.setItem('fluxrt_server',srv());
   $('stat').textContent='connecting…'; start().catch(e=>{$('stat').textContent='error: '+e.message;console.error(e);}); }
 function setModeLabel(){
-  $('modebtn').textContent = 'mode: '+(mode==='publish'?'publish 🔴':'listen 👂');
-  $('locallabel').textContent = mode==='publish' ? 'camera (you)' : 'camera — off (listening)';
+  const listen = mode!=='publish';
+  $('modebtn').textContent = 'mode: '+(listen?'listen 👂':'publish 🔴');
+  // listen: left pane shows the live pipeline input (GET /input.jpg) instead of
+  // our own camera, since a recvonly client sends nothing.
+  $('local').style.display    = listen ? 'none' : '';
+  $('inputimg').style.display = listen ? '' : 'none';
+  if(!listen){ $('inputimg').removeAttribute('src'); $('locallabel').textContent='camera (you)'; }
+  else $('locallabel').textContent='input — none (listening)';
 }
 function toggleMode(){ mode = mode==='publish' ? 'listen' : 'publish';
   localStorage.setItem('fluxrt_mode', mode); setModeLabel(); reconnect(); }
+
+// While listening, poll the server's current input frame into the left pane.
+let inputObjUrl=null;
+async function inputTick(){
+  if(mode!=='publish' && pc){
+    try{
+      const r = await fetch(S('/input.jpg'),{cache:'no-store'});
+      if(r.status===200){
+        const u = URL.createObjectURL(await r.blob());
+        $('inputimg').src = u;
+        if(inputObjUrl) URL.revokeObjectURL(inputObjUrl);
+        inputObjUrl = u;
+        $('locallabel').textContent='input (live)';
+      } else { // 204 = nothing driving input
+        $('inputimg').removeAttribute('src');
+        if(inputObjUrl){ URL.revokeObjectURL(inputObjUrl); inputObjUrl=null; }
+        $('locallabel').textContent='input — none (listening)';
+      }
+    }catch(_){ /* transient — keep last frame */ }
+  }
+  setTimeout(inputTick, mode!=='publish' ? 150 : 1000);
+}
 
 // --- ICE diagnostics: this is the comparison surface vs sd-webrtc ---
 let iceLines=[];
@@ -148,5 +176,6 @@ $('server').value = _q.get('server') || localStorage.getItem('fluxrt_server') ||
 // Boot in listening mode by default (?mode=publish or a prior toggle overrides).
 mode = _q.get('mode') || localStorage.getItem('fluxrt_mode') || 'listen';
 setModeLabel();
+inputTick();   // left-pane input preview while listening
 start().catch(e=>{ $('stat').textContent='error: '+e.message; console.error(e); });
 </script></body></html>

--- a/scripts/webrtc_test_client.html
+++ b/scripts/webrtc_test_client.html
@@ -108,17 +108,43 @@ async function start(){
   $('stat').textContent='connected'; poll();
 }
 
-let prev=null, prevT=0;
+// Client-side live-link stats from getStats() (this connection's RTT + throughput).
+let _statsPrev=null;
+async function connStats(){
+  if(!pc) return 'link      : (no pc)';
+  try{
+    const stats = await pc.getStats();
+    let rtt=null, out=0, inn=0, lost=0, ts=0;
+    stats.forEach(r=>{
+      if(r.type==='candidate-pair' && (r.nominated||r.selected||r.state==='succeeded') && r.currentRoundTripTime!=null) rtt=r.currentRoundTripTime;
+      if(r.type==='outbound-rtp' && r.kind==='video'){ out+=r.bytesSent||0; ts=r.timestamp||ts; }
+      if(r.type==='inbound-rtp'  && r.kind==='video'){ inn+=r.bytesReceived||0; lost+=r.packetsLost||0; ts=r.timestamp||ts; }
+    });
+    let up='-', down='-';
+    if(_statsPrev && ts>_statsPrev.ts){
+      const dt=(ts-_statsPrev.ts)/1000;
+      up=Math.round((out-_statsPrev.out)*8/1000/dt);
+      down=Math.round((inn-_statsPrev.inn)*8/1000/dt);
+    }
+    _statsPrev={ts,out,inn};
+    return `link      : up ${up}kbps  down ${down}kbps  rtt ${rtt!=null?Math.round(rtt*1000)+'ms':'-'}  lost ${lost}`;
+  }catch(e){ return 'link      : (stats err)'; }
+}
 async function poll(){
   try{
     const hz = await (await fetch(S('/healthz'),{cache:'no-store'})).json();
     const live = hz.input_source && hz.input_source!=='none';
+    const c = hz.connections || {};
+    const byState = Object.entries(c.by_state||{}).map(([k,v])=>`${k}:${v}`).join(' ') || '—';
+    const linkLine = await connStats();
     $('readout').innerHTML =
-      `peers     : ${hz.peers}   input_source: ${hz.input_source}\n`+
+      `pool      : ${c.total??hz.peers} conns   active ${c.active??'—'}   waiters ${hz.input_waiters??'—'}   input ${hz.input_source}\n`+
+      `  states  : ${byState}\n`+
+      `${linkLine}\n`+
       `resolution: ${hz.resolution?.width}x${hz.resolution?.height}\n`+
       `<span class="${live?'live':'dead'}">pipeline  : ${hz.fps_pipeline??'-'} fps   interp ${hz.fps_interpolated??'-'}   proc ${hz.proc_time_ms??'-'}ms   vram ${hz.vram_mb??'-'}MB</span>\n`+
       `prompt/seed/steps: ${hz.prompt} / ${hz.seed} / ${hz.steps}`;
-    $('stat').textContent = live ? 'connected · input live' : 'connected · NO INPUT';
+    $('stat').textContent = live ? `connected · input live · ${c.active??'?'}/${c.total??'?'} peers` : 'connected · NO INPUT';
   }catch(e){ $('stat').textContent='poll error'; }
   setTimeout(poll, 1000);
 }

--- a/scripts/webrtc_test_client.html
+++ b/scripts/webrtc_test_client.html
@@ -76,7 +76,11 @@ async function start(){
   $('local').srcObject = cam;
 
   // Negotiate on a LOCAL conn (race-safe — same fix as sd-webrtc).
-  const conn = new RTCPeerConnection();
+  // Client-side STUN is LOAD-BEARING: without it the client gathers only mDNS
+  // host candidates (no public srflx), so the server's public srflx has nothing
+  // to pair with → ICE fails. realtime-client has this; bare RTCPeerConnection()
+  // is why the standalone clients failed against the remote server.
+  const conn = new RTCPeerConnection({ iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] });
   pc = conn;
   conn.addTransceiver(cam.getVideoTracks()[0], {direction:'sendrecv', streams:[cam]});
   conn.ontrack = e => { $('remote').srcObject = e.streams[0];

--- a/src/fluxrt/stream_processor/model_inference_subprocess.py
+++ b/src/fluxrt/stream_processor/model_inference_subprocess.py
@@ -102,6 +102,14 @@ class ModelInferenceSubprocess:
         self.shared_state = self._manager.dict()
         self.interpolation_exp = self.config.get("interpolation_exp", 1)
 
+        # Batch mode: a synchronous one-output-per-input render loop (offline). The
+        # live free-run path leaves batch_mode False and never touches these.
+        self.batch_mode = bool(self.config.get("batch_mode", False))
+        self.proc_ready = Value("b", False)  # set once models are loaded (batch readiness)
+        self._seq = 0
+        self.request_queue = self._manager.Queue()   # parent -> worker: (seq, rgb)
+        self.response_queue = self._manager.Queue()  # worker -> parent: (seq, rgb_out)
+
     def __getstate__(self):
         # The subprocess is spawned via Process(target=self.process_main),
         # which pickles `self`. The SyncManager holds a weakref and is not
@@ -396,11 +404,38 @@ class ModelInferenceSubprocess:
 
     def start(self):
         self.running.value = True
-        self.process = Process(target=self.process_main)
+        target = self.process_main_batch if self.batch_mode else self.process_main
+        self.process = Process(target=target)
         self.process.start()
+
+    def submit_frame(self, frame_rgb, timeout: float = 300.0):
+        """Parent-side (batch): enqueue one frame and block for its rendered
+        output. Single consumer, processed strictly in order, so the response
+        belongs to this request. Polls so a DEAD child (e.g. CUDA OOM) fails fast
+        instead of blocking the job worker forever; raises on death or timeout."""
+        self._seq += 1
+        seq = self._seq
+        self.request_queue.put((seq, frame_rgb))
+        deadline = time.time() + timeout
+        while True:
+            try:
+                _, out = self.response_queue.get(timeout=0.5)
+                return out
+            except Empty:
+                if self.process is not None and not self.process.is_alive():
+                    raise RuntimeError("batch inference subprocess died during render")
+                if time.time() >= deadline:
+                    raise RuntimeError("batch render timed out waiting for the inference subprocess")
 
     def stop(self):
         self.running.value = False
+        if self.batch_mode:
+            # Wake the batch loop if it is blocked in request_queue.get() so it
+            # exits at once instead of waiting out the 0.2s poll timeout.
+            try:
+                self.request_queue.put(None)
+            except Exception:
+                pass
         if self.process:
             # Graceful first: let process_main observe running=False and exit
             # its loop. Escalate to terminate/kill if it is wedged in CUDA,
@@ -653,3 +688,33 @@ class ModelInferenceSubprocess:
             frame = self.convert_np_to_torch(frame)
             frames = self.interpolate_frames(frame)
             prev_time = self.sync_fps_and_send(prev_time, frames)
+
+    def process_main_batch(self):
+        """Synchronous one-output-per-input render loop for OFFLINE batch jobs.
+
+        Unlike process_main (the live free-run path), there is NO drain-to-latest,
+        NO interpolation, NO fixed-fps pacing and NO shared-tensor output: each
+        input frame arrives on request_queue, is rendered once via the SAME
+        pipeline call the live loop uses (process_frame_with_pipeline), and the
+        uint8 RGB result goes back on response_queue — exactly one output per input.
+
+        The temporal caches (update_controller, previous_frame) are NOT reset
+        between frames, so a video keeps its frame-to-frame coherence; they start
+        clean because this is a fresh, dedicated instance (process_init).
+        """
+        self.process_init()
+        self.proc_ready.value = True
+        while self.running.value:
+            try:
+                item = self.request_queue.get(timeout=0.2)
+            except Empty:
+                continue
+            if item is None:  # poison pill -> exit the loop on teardown
+                break
+            seq, frame_rgb = item
+            # Apply any prompt/seed/steps set on this instance before the job.
+            self.update_process_state()
+            out = self.process_frame_with_pipeline(frame_rgb)
+            if self.lip_processor is not None and self.lip_active:
+                out = self.lip_processor.process(out, frame_rgb)
+            self.response_queue.put((seq, out))

--- a/src/fluxrt/stream_processor/model_inference_subprocess.py
+++ b/src/fluxrt/stream_processor/model_inference_subprocess.py
@@ -3,6 +3,8 @@ import time
 import cv2
 import numpy as np
 import json
+import os
+import signal
 from safetensors.torch import load_file
 from multiprocessing import Process, Value, Manager
 from queue import Empty
@@ -300,6 +302,11 @@ class ModelInferenceSubprocess:
             max_sequence_length=512,
             text_encoder_out_layers=(9, 18, 27),
         )
+        # Full-frame execute (the expensive spatial-cache-disabling dense pass)
+        # is applied only every `stride` frames during the morph instead of
+        # every frame; >=1, default 2 (~halves the dense-execute cost). Override
+        # with config "prompt_travel_full_execute_every" (1 = old behaviour).
+        stride = max(1, int(self.config.get("prompt_travel_full_execute_every", 2)))
         self._travel = {
             "src": self.prompt_embeds,
             "tgt": target_embeds,
@@ -307,13 +314,18 @@ class ModelInferenceSubprocess:
             "i": 0,
             "mode": mode,
             "prompt": target_prompt,
+            "stride": stride,
         }
 
     def _advance_prompt_travel(self) -> None:
         """
         Called once per generated frame. Advances an in-progress morph by one
-        step: blends src->tgt embeddings and forces a full-frame execute so the
-        new conditioning actually reaches every pixel.
+        step: blends src->tgt embeddings so the new conditioning reaches the
+        frame. To keep the morph cheap, the EXPENSIVE full-frame execute (which
+        disables the spatial sparse cache and recomputes every image token) is
+        applied only every `stride` frames; the cheap text-K/V recompute runs
+        every frame so MOVING regions keep morphing smoothly, while STATIC
+        regions catch up on the strided full-execute frames.
         """
         tv = self._travel
         if tv is None:
@@ -329,15 +341,22 @@ class ModelInferenceSubprocess:
         else:
             self.prompt_embeds = slerp(tv["src"], tv["tgt"], t)
 
-        # Force the whole image to execute this frame. The spatial cache would
-        # otherwise skip static tokens and the interpolated prompt would never
-        # appear (text-only invalidation does not propagate to cached image
-        # tokens). Recompute text K/V too, but leave the reference-image cache
-        # intact so it is not re-encoded every frame.
-        self.update_controller.requires_reset = True
+        # Recompute text K/V every frame (cheap — 512 text tokens). Executing
+        # image tokens (the moving regions the spatial cache doesn't skip) cross-
+        # attend to the fresh K/V and pick up the new conditioning, so motion
+        # morphs smoothly every frame without a full dense execute.
         self.update_controller.text_is_valid = False
 
-        if tv["i"] >= tv["n"]:
+        # Full-frame execute (requires_reset -> ALL image tokens recompute) is
+        # the costly part that also drags STATIC/cached tokens onto the new
+        # conditioning. Stride it: the first frame, every `stride`th frame, and
+        # the final frame (which must land the exact target everywhere). Caps the
+        # dense-execute cost at ~1/stride of the per-frame version.
+        last = tv["i"] >= tv["n"]
+        if last or tv["i"] == 1 or tv["i"] % tv["stride"] == 0:
+            self.update_controller.requires_reset = True
+
+        if last:
             # Final frame was rendered at t=1.0 above; snap exactly onto the
             # target embeds and update tracked prompt state.
             self.prompt_embeds = tv["tgt"]
@@ -412,6 +431,22 @@ class ModelInferenceSubprocess:
             if self.process.is_alive():
                 self.process.kill()
                 self.process.join(timeout=2)
+            if self.process.is_alive():
+                # SIGKILL didn't reap within 2s — typically a child stuck in an
+                # uninterruptible CUDA driver syscall (D state). Re-signal and
+                # DETACH it from multiprocessing's _children so the interpreter-
+                # exit atexit join (which has NO timeout) can never block on this
+                # pid and leave an orphaned GPU process needing a manual kill.
+                try:
+                    os.kill(self.process.pid, signal.SIGKILL)
+                except Exception:
+                    pass
+                try:
+                    import multiprocessing.process as _mpp
+
+                    _mpp._children.discard(self.process)
+                except Exception:
+                    pass
             self.process = None
         # Tear down the Manager process spawned in __init__; otherwise it
         # lingers as an orphan after the main process exits.
@@ -637,6 +672,12 @@ class ModelInferenceSubprocess:
         return frame
 
     def process_main(self):
+        # Ignore SIGINT in the child. With the "spawn" start method the child
+        # shares the parent's process group, so Ctrl+C is delivered here too;
+        # the default handler would raise KeyboardInterrupt mid-CUDA and can
+        # leave a half-torn context (D state) that resists kill. Shut down only
+        # via running.value (parent flips it in stop()) / parent terminate+kill.
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
         self.process_init()
         prev_time = time.time()
         while self.running.value:

--- a/src/fluxrt/stream_processor/model_inference_subprocess.py
+++ b/src/fluxrt/stream_processor/model_inference_subprocess.py
@@ -33,6 +33,7 @@ from accelerate import init_empty_weights
 from fluxrt.stream_processor.interpolation_model import IFNet
 from fluxrt.stream_processor.transformer_flux2 import Flux2Transformer2DModel
 from fluxrt.utils.shared_tensor import SharedTensor
+from fluxrt.utils import crop_maximal_rectangle
 from fluxrt.stream_processor.pipeline import Flux2KleinPipeline
 from fluxrt.stream_processor.update_controller import UpdateController
 from fluxrt.stream_processor.postprocessors import (
@@ -727,6 +728,12 @@ class ModelInferenceSubprocess:
             if item is None:  # poison pill -> exit the loop on teardown
                 break
             seq, frame_rgb = item
+            # The model only ever sees frames at its OWN resolution — the live path
+            # crops every frame via push_input_frame before it reaches the pipeline.
+            # Batch inputs are arbitrary-size video frames, so crop+resize to
+            # (height, width) here too; otherwise the spatial-cache mask length won't
+            # match the model's token count (e.g. a 1080p frame → oversized mask).
+            frame_rgb = crop_maximal_rectangle(frame_rgb, self.height, self.width)
             # Apply any prompt/seed/steps set on this instance before the job.
             self.update_process_state()
             out = self.process_frame_with_pipeline(frame_rgb)

--- a/src/fluxrt/stream_processor/model_inference_subprocess.py
+++ b/src/fluxrt/stream_processor/model_inference_subprocess.py
@@ -735,8 +735,10 @@ class ModelInferenceSubprocess:
             # (height, width) here too; otherwise the spatial-cache mask length won't
             # match the model's token count (e.g. a 1080p frame → oversized mask).
             frame_rgb = crop_maximal_rectangle(frame_rgb, self.height, self.width)
-            # Apply any prompt/seed/steps set on this instance before the job.
+            # Drain prompt/seed/steps set before OR during the job (live steering),
+            # then step any in-progress slerp morph — same order as the live loop.
             self.update_process_state()
+            self._advance_prompt_travel()
             out = self.process_frame_with_pipeline(frame_rgb)
             if self.lip_processor is not None and self.lip_active:
                 out = self.lip_processor.process(out, frame_rgb)

--- a/src/fluxrt/stream_processor/model_inference_subprocess.py
+++ b/src/fluxrt/stream_processor/model_inference_subprocess.py
@@ -8,6 +8,21 @@ from multiprocessing import Process, Value, Manager
 from queue import Empty
 from PIL import Image
 
+# ── torch.compile / Dynamo tuning ─────────────────────────────────────────────
+# The spatial-cache transformer in transformer_flux2.py specializes Dynamo
+# graphs on (a) per-block KV cache indexing (single_block_keys[block_id] for 20
+# distinct block_id values) and (b) sparse_mlp_compute() shapes that change
+# with the per-frame active-token mask. The default recompile_limit (8) gives
+# up partway and falls back to eager mode for the remaining graphs, costing
+# ~10-25% throughput. Raising the limit lets every variant compile, then warm
+# up once and stay hot.
+try:
+    torch._dynamo.config.recompile_limit = 64
+    torch._dynamo.config.cache_size_limit = 256
+except AttributeError:
+    # Older torch builds without _dynamo.config — skip silently; nothing breaks.
+    pass
+
 from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
 from diffusers.models import AutoencoderKLFlux2
 from transformers import Qwen2TokenizerFast, Qwen3ForCausalLM, AutoConfig
@@ -26,6 +41,37 @@ from fluxrt.stream_processor.postprocessors import (
 from fluxrt.flow_upscaler.upscaler_unet import UpscalerUNet
 from fluxrt.flow_upscaler.flow_upscaler_pipeline import FlowUpscalerPipeline
 from fluxrt.stream_processor.flux_tiny_vae import DiffusersTAEF2Wrapper
+
+
+def slerp(a: torch.Tensor, b: torch.Tensor, t: float, eps: float = 1e-6) -> torch.Tensor:
+    """
+    Spherical-linear interpolation between two prompt-embedding tensors.
+
+    `a` and `b` are treated as single flattened vectors. slerp keeps the
+    interpolant's norm roughly constant through the midpoint, which avoids the
+    washed-out / low-contrast middle that plain lerp can produce on conditioning
+    tensors. Computed in float32 for numerical stability, then cast back to the
+    input dtype (the embeddings are bfloat16). Falls back to lerp when the two
+    vectors are nearly colinear (sin(theta) -> 0).
+    """
+    # Compute only the angle/weights in float32 (scalars — cheap, numerically
+    # stable). The flattened float32 copies used for the dot product are
+    # transient and freed immediately; the final blend is done in the input
+    # dtype (bfloat16) to avoid materializing a full-size float32 result every
+    # frame on the memory-tight prompt-travel hot path.
+    af, bf = a.flatten().float(), b.flatten().float()
+    dot = (af @ bf) / (af.norm() * bf.norm() + eps)
+    dot = dot.clamp(-1.0, 1.0)
+    # Fall back to lerp when nearly colinear in EITHER direction. Near-parallel
+    # (dot -> 1) slerp == lerp anyway; near-anti-parallel (dot -> -1) makes
+    # sin(theta) -> 0, so the slerp divisor blows up — lerp is the safe path.
+    if dot.abs() > 0.9995:
+        return torch.lerp(a, b, t)
+    theta = torch.acos(dot)
+    sin_theta = torch.sin(theta)
+    w_a = (torch.sin((1.0 - t) * theta) / sin_theta).to(a.dtype)
+    w_b = (torch.sin(t * theta) / sin_theta).to(a.dtype)
+    return w_a * a + w_b * b
 
 
 class ModelInferenceSubprocess:
@@ -51,10 +97,20 @@ class ModelInferenceSubprocess:
         self.pack_is_ready = pack_is_ready
         self.last_processing_time = last_processing_time
 
-        manager = Manager()
-        self.command_queue = manager.Queue()
-        self.shared_state = manager.dict()
+        self._manager = Manager()
+        self.command_queue = self._manager.Queue()
+        self.shared_state = self._manager.dict()
         self.interpolation_exp = self.config.get("interpolation_exp", 1)
+
+    def __getstate__(self):
+        # The subprocess is spawned via Process(target=self.process_main),
+        # which pickles `self`. The SyncManager holds a weakref and is not
+        # picklable, so drop it from the child's state. Only the parent calls
+        # stop(), where _manager still exists; the picklable queue/dict
+        # proxies the child actually uses are kept.
+        state = self.__dict__.copy()
+        state.pop("_manager", None)
+        return state
 
     def enable_quantization(self):
         """
@@ -70,6 +126,9 @@ class ModelInferenceSubprocess:
             "steps": self.config["default_steps"],
             "seed": self.config["default_seed"],
         }
+        # Active prompt-travel state, or None when no morph is in progress.
+        # Populated by _begin_prompt_travel(), advanced in process_main().
+        self._travel = None
 
     def load_models_without_quantization(self):
         device = self.device
@@ -221,7 +280,69 @@ class ModelInferenceSubprocess:
             max_sequence_length=512,
             text_encoder_out_layers=(9, 18, 27),
         )
+        # A direct prompt set cancels any in-progress morph.
+        self._travel = None
         self.update_controller.reset_cache()
+
+    def _begin_prompt_travel(self, payload: dict) -> None:
+        """
+        Worker-side handler: pre-encode the target prompt ONCE and arm the
+        travel state. Encoding (the text-encoder forward) is the expensive part,
+        so it must not run per frame — only the cheap blend does.
+        """
+        target_prompt = payload["prompt"]
+        frames = max(1, int(payload.get("frames", 48)))
+        mode = payload.get("mode", "slerp")
+        target_embeds, _ = self.pipe.encode_prompt(
+            prompt=target_prompt,
+            device=self.device,
+            num_images_per_prompt=1,
+            max_sequence_length=512,
+            text_encoder_out_layers=(9, 18, 27),
+        )
+        self._travel = {
+            "src": self.prompt_embeds,
+            "tgt": target_embeds,
+            "n": frames,
+            "i": 0,
+            "mode": mode,
+            "prompt": target_prompt,
+        }
+
+    def _advance_prompt_travel(self) -> None:
+        """
+        Called once per generated frame. Advances an in-progress morph by one
+        step: blends src->tgt embeddings and forces a full-frame execute so the
+        new conditioning actually reaches every pixel.
+        """
+        tv = self._travel
+        if tv is None:
+            return
+
+        # Advance first so the morph renders exactly tv["n"] frames, every one of
+        # them showing progress: the first frame is at t=1/n (not t=0, which
+        # would be the unchanged source) and the last is at t=n/n=1.0 (target).
+        tv["i"] += 1
+        t = tv["i"] / tv["n"]
+        if tv["mode"] == "lerp":
+            self.prompt_embeds = torch.lerp(tv["src"], tv["tgt"], t)
+        else:
+            self.prompt_embeds = slerp(tv["src"], tv["tgt"], t)
+
+        # Force the whole image to execute this frame. The spatial cache would
+        # otherwise skip static tokens and the interpolated prompt would never
+        # appear (text-only invalidation does not propagate to cached image
+        # tokens). Recompute text K/V too, but leave the reference-image cache
+        # intact so it is not re-encoded every frame.
+        self.update_controller.requires_reset = True
+        self.update_controller.text_is_valid = False
+
+        if tv["i"] >= tv["n"]:
+            # Final frame was rendered at t=1.0 above; snap exactly onto the
+            # target embeds and update tracked prompt state.
+            self.prompt_embeds = tv["tgt"]
+            self.process_state["prompt"] = tv["prompt"]
+            self._travel = None
 
     def init_shared_tensors(self):
         height, width = self.resolution["height"], self.resolution["width"]
@@ -281,7 +402,25 @@ class ModelInferenceSubprocess:
     def stop(self):
         self.running.value = False
         if self.process:
-            self.process.join()
+            # Graceful first: let process_main observe running=False and exit
+            # its loop. Escalate to terminate/kill if it is wedged in CUDA,
+            # torch.compile, or a blocking call so Ctrl+C never hangs.
+            self.process.join(timeout=5)
+            if self.process.is_alive():
+                self.process.terminate()
+                self.process.join(timeout=3)
+            if self.process.is_alive():
+                self.process.kill()
+                self.process.join(timeout=2)
+            self.process = None
+        # Tear down the Manager process spawned in __init__; otherwise it
+        # lingers as an orphan after the main process exits.
+        if getattr(self, "_manager", None) is not None:
+            try:
+                self._manager.shutdown()
+            except Exception:
+                pass
+            self._manager = None
 
     def set_param(self, name: str, value) -> None:
         self.command_queue.put(("set_param", (name, value)))
@@ -312,6 +451,22 @@ class ModelInferenceSubprocess:
 
     def set_lip_transfer(self, enabled: bool) -> None:
         self.command_queue.put(("set_lip_transfer", enabled))
+
+    def start_prompt_travel(
+        self, target_prompt: str, frames: int = 48, mode: str = "slerp"
+    ) -> None:
+        """
+        Smoothly interpolate the conditioning from the current prompt to
+        `target_prompt` over `frames` generated frames. `mode` is "slerp" or
+        "lerp". Enqueues onto the command queue; handled in the inference
+        subprocess by _begin_prompt_travel / _advance_prompt_travel.
+        """
+        self.command_queue.put(
+            (
+                "start_prompt_travel",
+                {"prompt": target_prompt, "frames": int(frames), "mode": mode},
+            )
+        )
 
     def update_process_state(self) -> None:
         """
@@ -353,6 +508,9 @@ class ModelInferenceSubprocess:
 
                 elif cmd == "set_lip_transfer":
                     self.lip_active = payload
+
+                elif cmd == "start_prompt_travel":
+                    self._begin_prompt_travel(payload)
 
         except Empty:
             pass
@@ -483,6 +641,7 @@ class ModelInferenceSubprocess:
         prev_time = time.time()
         while self.running.value:
             self.update_process_state()
+            self._advance_prompt_travel()
             original_frame = self.input_shared_tensor.to_numpy()
             original_frame = cv2.cvtColor(original_frame, cv2.COLOR_BGR2RGB)
             frame = self.process_frame_with_pipeline(original_frame)

--- a/src/fluxrt/stream_processor/model_inference_subprocess.py
+++ b/src/fluxrt/stream_processor/model_inference_subprocess.py
@@ -419,34 +419,14 @@ class ModelInferenceSubprocess:
         self.process.start()
 
     def stop(self):
+        # Reap the child with a bounded escalation that also detaches a SIGKILL
+        # survivor from multiprocessing._children (so the no-timeout atexit join
+        # can't hang the parent). See fluxrt.webrtc.proc.reap_process.
+        from fluxrt.webrtc.proc import reap_process
+
         self.running.value = False
         if self.process:
-            # Graceful first: let process_main observe running=False and exit
-            # its loop. Escalate to terminate/kill if it is wedged in CUDA,
-            # torch.compile, or a blocking call so Ctrl+C never hangs.
-            self.process.join(timeout=5)
-            if self.process.is_alive():
-                self.process.terminate()
-                self.process.join(timeout=3)
-            if self.process.is_alive():
-                self.process.kill()
-                self.process.join(timeout=2)
-            if self.process.is_alive():
-                # SIGKILL didn't reap within 2s — typically a child stuck in an
-                # uninterruptible CUDA driver syscall (D state). Re-signal and
-                # DETACH it from multiprocessing's _children so the interpreter-
-                # exit atexit join (which has NO timeout) can never block on this
-                # pid and leave an orphaned GPU process needing a manual kill.
-                try:
-                    os.kill(self.process.pid, signal.SIGKILL)
-                except Exception:
-                    pass
-                try:
-                    import multiprocessing.process as _mpp
-
-                    _mpp._children.discard(self.process)
-                except Exception:
-                    pass
+            reap_process(self.process)
             self.process = None
         # Tear down the Manager process spawned in __init__; otherwise it
         # lingers as an orphan after the main process exits.
@@ -672,12 +652,6 @@ class ModelInferenceSubprocess:
         return frame
 
     def process_main(self):
-        # Ignore SIGINT in the child. With the "spawn" start method the child
-        # shares the parent's process group, so Ctrl+C is delivered here too;
-        # the default handler would raise KeyboardInterrupt mid-CUDA and can
-        # leave a half-torn context (D state) that resists kill. Shut down only
-        # via running.value (parent flips it in stop()) / parent terminate+kill.
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
         self.process_init()
         prev_time = time.time()
         while self.running.value:

--- a/src/fluxrt/stream_processor/model_inference_subprocess.py
+++ b/src/fluxrt/stream_processor/model_inference_subprocess.py
@@ -429,10 +429,11 @@ class ModelInferenceSubprocess:
         self.process.start()
 
     def submit_frame(self, frame_rgb, timeout: float = 300.0):
-        """Parent-side (batch): enqueue one frame and block for its rendered
-        output. Single consumer, processed strictly in order, so the response
-        belongs to this request. Polls so a DEAD child (e.g. CUDA OOM) fails fast
-        instead of blocking the job worker forever; raises on death or timeout."""
+        """Parent-side (batch): enqueue one frame and block for its rendered output
+        — a LIST of uint8 RGB frames (one for 1:1, 2**interpolation_exp when
+        interpolating). Single consumer, processed strictly in order, so the
+        response belongs to this request. Polls so a DEAD child (e.g. CUDA OOM)
+        fails fast instead of blocking the worker forever; raises on death/timeout."""
         self._seq += 1
         seq = self._seq
         self.request_queue.put((seq, frame_rgb))
@@ -739,4 +740,12 @@ class ModelInferenceSubprocess:
             out = self.process_frame_with_pipeline(frame_rgb)
             if self.lip_processor is not None and self.lip_active:
                 out = self.lip_processor.process(out, frame_rgb)
-            self.response_queue.put((seq, out))
+            # interpolation_exp == 0 → exactly one output per input (1:1). >0 → RIFE
+            # interpolation emits 2**exp frames per input (smoother / higher fps);
+            # the caller scales the output fps by the same factor.
+            if self.interpolation_exp <= 0:
+                outs = [out]
+            else:
+                batch = self.interpolate_frames(self.convert_np_to_torch(out))  # (2**exp,H,W,3) BGR
+                outs = [batch[j][:, :, ::-1].copy() for j in range(batch.shape[0])]  # -> RGB
+            self.response_queue.put((seq, outs))

--- a/src/fluxrt/stream_processor/output_scheduler_subprocess.py
+++ b/src/fluxrt/stream_processor/output_scheduler_subprocess.py
@@ -34,7 +34,14 @@ class OutputSchedulerSubprocess:
     def stop(self) -> None:
         self.running.value = False
         if self.process:
-            self.process.join()
+            self.process.join(timeout=5)
+            if self.process.is_alive():
+                self.process.terminate()
+                self.process.join(timeout=3)
+            if self.process.is_alive():
+                self.process.kill()
+                self.process.join(timeout=2)
+            self.process = None
 
     def process_init(self) -> None:
         """

--- a/src/fluxrt/stream_processor/output_scheduler_subprocess.py
+++ b/src/fluxrt/stream_processor/output_scheduler_subprocess.py
@@ -34,28 +34,11 @@ class OutputSchedulerSubprocess:
         self.process.start()
 
     def stop(self) -> None:
+        from fluxrt.webrtc.proc import reap_process
+
         self.running.value = False
         if self.process:
-            self.process.join(timeout=5)
-            if self.process.is_alive():
-                self.process.terminate()
-                self.process.join(timeout=3)
-            if self.process.is_alive():
-                self.process.kill()
-                self.process.join(timeout=2)
-            if self.process.is_alive():
-                # Detach a SIGKILL survivor from multiprocessing's _children so
-                # the no-timeout atexit join can't hang the parent on exit.
-                try:
-                    os.kill(self.process.pid, signal.SIGKILL)
-                except Exception:
-                    pass
-                try:
-                    import multiprocessing.process as _mpp
-
-                    _mpp._children.discard(self.process)
-                except Exception:
-                    pass
+            reap_process(self.process)
             self.process = None
 
     def process_init(self) -> None:
@@ -78,9 +61,6 @@ class OutputSchedulerSubprocess:
         )
 
     def process_main(self) -> None:
-        # See ModelInferenceSubprocess.process_main: ignore SIGINT in the child
-        # so Ctrl+C doesn't KeyboardInterrupt it mid-loop; exit via running.value.
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
         self.process_init()
 
         while self.running.value:

--- a/src/fluxrt/stream_processor/output_scheduler_subprocess.py
+++ b/src/fluxrt/stream_processor/output_scheduler_subprocess.py
@@ -1,5 +1,7 @@
 from multiprocessing import Process, Value
 from fluxrt.utils.shared_tensor import SharedTensor
+import os
+import signal
 import time
 
 
@@ -41,6 +43,19 @@ class OutputSchedulerSubprocess:
             if self.process.is_alive():
                 self.process.kill()
                 self.process.join(timeout=2)
+            if self.process.is_alive():
+                # Detach a SIGKILL survivor from multiprocessing's _children so
+                # the no-timeout atexit join can't hang the parent on exit.
+                try:
+                    os.kill(self.process.pid, signal.SIGKILL)
+                except Exception:
+                    pass
+                try:
+                    import multiprocessing.process as _mpp
+
+                    _mpp._children.discard(self.process)
+                except Exception:
+                    pass
             self.process = None
 
     def process_init(self) -> None:
@@ -63,6 +78,9 @@ class OutputSchedulerSubprocess:
         )
 
     def process_main(self) -> None:
+        # See ModelInferenceSubprocess.process_main: ignore SIGINT in the child
+        # so Ctrl+C doesn't KeyboardInterrupt it mid-loop; exit via running.value.
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
         self.process_init()
 
         while self.running.value:

--- a/src/fluxrt/stream_processor/pipeline.py
+++ b/src/fluxrt/stream_processor/pipeline.py
@@ -258,6 +258,7 @@ class Flux2KleinPipeline(DiffusionPipeline, Flux2LoraLoaderMixin):
         self.upscaler_pipeline = upscaler_pipeline
 
     @staticmethod
+    @torch.no_grad()
     def _get_qwen3_prompt_embeds(
         text_encoder: Qwen3ForCausalLM,
         tokenizer: Qwen2TokenizerFast,
@@ -267,6 +268,10 @@ class Flux2KleinPipeline(DiffusionPipeline, Flux2LoraLoaderMixin):
         max_sequence_length: int = 512,
         hidden_states_layers: list[int] = (9, 18, 27),
     ):
+        # Inference-only encode. Without no_grad the text-encoder forward retains
+        # autograd activations across all layers (~hundreds of MiB), which OOMs
+        # at runtime when called outside the pipeline's no_grad __call__ (e.g.
+        # update_prompt_embeds / prompt travel) on a near-full GPU.
         dtype = text_encoder.dtype if dtype is None else dtype
         device = text_encoder.device if device is None else device
 

--- a/src/fluxrt/stream_processor/stream_processor.py
+++ b/src/fluxrt/stream_processor/stream_processor.py
@@ -12,8 +12,22 @@ import numpy as np
 
 
 class StreamProcessor:
-    def __init__(self, config_path: str):
-        self.config = self.parse_config(config_path)
+    def __init__(self, config):
+        # `config` is a path to a JSON config OR an already-parsed config dict.
+        # The batch render clones the live config and overrides a few keys, so it
+        # constructs a StreamProcessor from a dict rather than a file. Copy a passed
+        # dict so the batch-mode mutation below can never reach a config a live
+        # processor shares (defense-in-depth on top of the caller's deepcopy).
+        self.config = dict(config) if isinstance(config, dict) else self.parse_config(config)
+        # Batch mode: a dedicated OFFLINE instance that renders exactly one output
+        # per submit_frame() — synchronous, no interpolation, no output scheduler.
+        # Separate from the live free-run path (which never sets this).
+        self.batch_mode = bool(self.config.get("batch_mode", False))
+        # Batch is strictly one output per input — force interpolation off before
+        # the tensor sizes are derived (both subprocesses re-read this key, so they
+        # must agree on the shape).
+        if self.batch_mode:
+            self.config["interpolation_exp"] = 0
         self.resolution = self.config["resolution"]
         output_batch_size = 2 ** self.config["interpolation_exp"]
 
@@ -46,14 +60,20 @@ class StreamProcessor:
             self.last_processing_time,
         )
 
-        self.output_scheduler_subprocess = OutputSchedulerSubprocess(
-            self.config,
-            self.output_batch_shared_tensor.name,
-            self.output_shared_tensor.name,
-            self.pack_is_ready,
-            self.last_processing_time,
-            self.frame_written,
-        )
+        # Batch mode returns frames synchronously via submit_frame(), so the
+        # fixed-fps output scheduler (which paces latest_rgb for the live track)
+        # is not started.
+        if self.batch_mode:
+            self.output_scheduler_subprocess = None
+        else:
+            self.output_scheduler_subprocess = OutputSchedulerSubprocess(
+                self.config,
+                self.output_batch_shared_tensor.name,
+                self.output_shared_tensor.name,
+                self.pack_is_ready,
+                self.last_processing_time,
+                self.frame_written,
+            )
 
     def parse_config(self, config_path: str) -> dict:
         with open(config_path, "r") as file:
@@ -61,7 +81,21 @@ class StreamProcessor:
 
     def start(self) -> None:
         self.model_inference_subprocess.start()
-        self.output_scheduler_subprocess.start()
+        if self.output_scheduler_subprocess is not None:
+            self.output_scheduler_subprocess.start()
+
+    def submit_frame(self, frame_rgb: np.ndarray, timeout: float = 300.0) -> np.ndarray:
+        """Batch mode only: render ONE input frame synchronously and return its
+        output (uint8 RGB). Blocks until the inference subprocess produces it."""
+        if not self.batch_mode:
+            raise RuntimeError("submit_frame() requires batch_mode=true")
+        return self.model_inference_subprocess.submit_frame(frame_rgb, timeout=timeout)
+
+    def worker_alive(self) -> bool:
+        """Is the inference subprocess running? Lets a batch caller fail fast if the
+        child died (e.g. CUDA OOM during model load) instead of waiting forever."""
+        p = getattr(self.model_inference_subprocess, "process", None)
+        return bool(p is not None and p.is_alive())
 
     def get_input_tensor(self) -> SharedTensor:
         return self.input_shared_tensor
@@ -72,13 +106,15 @@ class StreamProcessor:
     def stop(self) -> None:
         # Run every teardown step even if an earlier one raises, so a single
         # failure can't leak subprocesses or shared-memory segments.
-        for step in (
-            self.model_inference_subprocess.stop,
-            self.output_scheduler_subprocess.stop,
+        steps = [self.model_inference_subprocess.stop]
+        if self.output_scheduler_subprocess is not None:
+            steps.append(self.output_scheduler_subprocess.stop)
+        steps += [
             self.input_shared_tensor.close_and_unlink,
             self.output_shared_tensor.close_and_unlink,
             self.output_batch_shared_tensor.close_and_unlink,
-        ):
+        ]
+        for step in steps:
             try:
                 step()
             except Exception as exc:
@@ -126,6 +162,10 @@ class StreamProcessor:
         return self.out_resolution
 
     def is_ready(self) -> bool:
+        # Batch mode has no output scheduler (frame_written stays False); readiness
+        # is the inference subprocess having loaded its models.
+        if self.batch_mode:
+            return bool(self.model_inference_subprocess.proc_ready.value)
         return bool(self.frame_written.value)
 
     def get_input_shared_tensor_name(self) -> str:

--- a/src/fluxrt/stream_processor/stream_processor.py
+++ b/src/fluxrt/stream_processor/stream_processor.py
@@ -70,14 +70,31 @@ class StreamProcessor:
         return self.output_shared_tensor
 
     def stop(self) -> None:
-        self.model_inference_subprocess.stop()
-        self.output_scheduler_subprocess.stop()
-        self.input_shared_tensor.close_and_unlink()
-        self.output_shared_tensor.close_and_unlink()
-        self.output_batch_shared_tensor.close_and_unlink()
+        # Run every teardown step even if an earlier one raises, so a single
+        # failure can't leak subprocesses or shared-memory segments.
+        for step in (
+            self.model_inference_subprocess.stop,
+            self.output_scheduler_subprocess.stop,
+            self.input_shared_tensor.close_and_unlink,
+            self.output_shared_tensor.close_and_unlink,
+            self.output_batch_shared_tensor.close_and_unlink,
+        ):
+            try:
+                step()
+            except Exception as exc:
+                print(f"StreamProcessor.stop: {step.__qualname__} failed: {exc}")
 
     def set_prompt(self, prompt: str) -> None:
         self.model_inference_subprocess.set_param(name="prompt", value=prompt)
+
+    def start_prompt_travel(
+        self, target_prompt: str, frames: int = 48, mode: str = "slerp"
+    ) -> None:
+        """Smoothly morph from the current prompt to target_prompt over
+        `frames` generated frames (mode: "slerp" or "lerp")."""
+        self.model_inference_subprocess.start_prompt_travel(
+            target_prompt, frames, mode
+        )
 
     def set_steps(self, steps: int) -> None:
         self.model_inference_subprocess.set_param(name="steps", value=steps)

--- a/src/fluxrt/stream_processor/stream_processor.py
+++ b/src/fluxrt/stream_processor/stream_processor.py
@@ -23,11 +23,9 @@ class StreamProcessor:
         # per submit_frame() — synchronous, no interpolation, no output scheduler.
         # Separate from the live free-run path (which never sets this).
         self.batch_mode = bool(self.config.get("batch_mode", False))
-        # Batch is strictly one output per input — force interpolation off before
-        # the tensor sizes are derived (both subprocesses re-read this key, so they
-        # must agree on the shape).
-        if self.batch_mode:
-            self.config["interpolation_exp"] = 0
+        # interpolation_exp is honored as-is: the batch caller sets it per job
+        # (0 = 1:1, k>0 = 2**k interpolated frames per input). Both subprocesses
+        # re-read this key, so they agree on the output-batch tensor shape.
         self.resolution = self.config["resolution"]
         output_batch_size = 2 ** self.config["interpolation_exp"]
 
@@ -84,9 +82,10 @@ class StreamProcessor:
         if self.output_scheduler_subprocess is not None:
             self.output_scheduler_subprocess.start()
 
-    def submit_frame(self, frame_rgb: np.ndarray, timeout: float = 300.0) -> np.ndarray:
+    def submit_frame(self, frame_rgb: np.ndarray, timeout: float = 300.0) -> list:
         """Batch mode only: render ONE input frame synchronously and return its
-        output (uint8 RGB). Blocks until the inference subprocess produces it."""
+        output frames — a LIST of uint8 RGB (one for 1:1, 2**interpolation_exp when
+        interpolating). Blocks until the inference subprocess produces them."""
         if not self.batch_mode:
             raise RuntimeError("submit_frame() requires batch_mode=true")
         return self.model_inference_subprocess.submit_frame(frame_rgb, timeout=timeout)

--- a/src/fluxrt/webrtc/__init__.py
+++ b/src/fluxrt/webrtc/__init__.py
@@ -1,0 +1,8 @@
+"""
+WebRTC connection/lifecycle logic for the FluxRT streaming server.
+
+Deliberately torch-free so the input-ownership state machine, the per-peer
+recv policy, and the subprocess-reap helper can be unit-tested on a laptop
+without the diffusion model (or a GPU). scripts/run_webrtc.py wires these
+together with aiortc / FastAPI / the StreamProcessor.
+"""

--- a/src/fluxrt/webrtc/input_ownership.py
+++ b/src/fluxrt/webrtc/input_ownership.py
@@ -1,0 +1,248 @@
+"""
+Input-ownership state machine + per-peer input consumer for the FluxRT WebRTC
+server.
+
+The oldest-connected peer with a live video track steers the pipeline input;
+every other peer views the output. When the steering peer leaves, the oldest
+waiter takes over; if none remain, the local server camera resumes (or the
+output holds its last frame under --no-server-camera).
+
+This module is torch/aiortc/FastAPI-free *to import* (aiortc's MediaStreamError
+is imported with a fallback) so the ownership transitions and the recv policy
+are unit-testable with fake tracks and fake peer-connection objects.
+
+recv POLICY (this is the bug class that regressed in c855950):
+- An OWNER is NEVER evicted because of a frame gap. A healthy owner legitimately
+  produces no frame for >5s (first keyframe after claiming, ICE/DTLS/TURN settle,
+  a brief stall, a paused camera). Death is detected out-of-band: the caller's
+  connectionstatechange handler cancels this task when the pc goes terminal.
+- A WAITER is bounded only on its FIRST frame: a peer that never delivers a frame
+  AND is not in the 'connected' ICE state is a dead reconnect and is dropped after
+  WAITER_FIRST_FRAME_DEADLINE. Once it has delivered a frame, it is never evicted
+  on a gap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import itertools
+import threading
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Optional
+
+try:  # aiortc is present on the server, absent in unit tests.
+    from aiortc.mediastreams import MediaStreamError
+except Exception:  # pragma: no cover - exercised only when aiortc is installed
+
+    class MediaStreamError(Exception):
+        """Fallback so this module imports without aiortc (tests)."""
+
+
+# ── recv policy ───────────────────────────────────────────────────────────────
+# Terminal connection states: the pc is dead, ownership/waiter slot must release.
+TERMINAL_STATES = ("failed", "closed", "disconnected")
+# How long a waiter that has NEVER delivered a frame may stay before it is treated
+# as a dead reconnect (only if it is also not 'connected').
+WAITER_FIRST_FRAME_DEADLINE = 25.0
+
+
+def owner_should_release(connection_state: str) -> bool:
+    """An owner is released ONLY on a terminal connection state, never on a frame
+    gap. (c855950 evicted on a blind 5s recv timeout regardless of state — that
+    froze healthy owners; this is the fix.)"""
+    return connection_state in TERMINAL_STATES
+
+
+def waiter_should_evict(
+    connection_state: str, got_first_frame: bool, deadline_passed: bool
+) -> bool:
+    """A waiter is evicted only if it has never delivered a frame, its first-frame
+    deadline passed, and it is not currently 'connected'. A connected-but-slow
+    waiter keeps waiting; a waiter that delivered a frame is never gap-evicted."""
+    return (not got_first_frame) and deadline_passed and connection_state != "connected"
+
+
+def _conn_state(pc) -> str:
+    return getattr(pc, "connectionState", "connected")
+
+
+@dataclass(frozen=True)
+class ReleaseOutcome:
+    """Result of release(): the I/O (broadcasts) is the caller's job, the decision
+    lives here."""
+
+    had_owner: bool
+    became_idle: bool  # ownership went None AND no waiters remain
+    server_camera_resumes: bool
+
+
+class InputOwnership:
+    """Single owner of the input-steering state. All of input_owner / waiters /
+    the active flag / the seq counter are mutated only here, under one lock — so
+    a phantom consumer can never pin the active flag against a dead pc."""
+
+    def __init__(self, has_server_camera: bool = True):
+        self._lock = threading.Lock()
+        self._owner = None  # pc identity, or None
+        self._waiters: dict[int, object] = {}  # seq -> pc
+        self._seq = itertools.count()
+        self._active = threading.Event()  # the producer thread waits on this
+        self.has_server_camera = has_server_camera
+
+    def register_waiter(self, pc) -> int:
+        with self._lock:
+            seq = next(self._seq)
+            self._waiters[seq] = pc
+            return seq
+
+    def try_claim(self, seq: int, pc) -> bool:
+        """Become owner iff no one owns and this seq is the oldest waiter.
+        Idempotent if already owner."""
+        with self._lock:
+            if self._owner is pc:
+                return True
+            if self._owner is None and self._waiters and seq == min(self._waiters):
+                self._owner = pc
+                self._active.set()
+                return True
+            return False
+
+    def release(self, seq: int, pc) -> ReleaseOutcome:
+        """The ONLY path that clears ownership / the active flag."""
+        with self._lock:
+            self._waiters.pop(seq, None)
+            had_owner = self._owner is pc
+            if had_owner:
+                self._owner = None
+            became_idle = False
+            server_camera_resumes = False
+            if self._owner is None and not self._waiters and self._active.is_set():
+                self._active.clear()
+                became_idle = True
+                server_camera_resumes = self.has_server_camera
+            return ReleaseOutcome(had_owner, became_idle, server_camera_resumes)
+
+    def owner_is(self, pc) -> bool:
+        with self._lock:
+            return self._owner is pc
+
+    def is_active(self) -> bool:
+        return self._active.is_set()
+
+    def active_event(self) -> threading.Event:
+        """The same Event the local camera producer thread waits on."""
+        return self._active
+
+    def num_waiters(self) -> int:
+        with self._lock:
+            return len(self._waiters)
+
+
+# Type of the frame sink: an async callable that consumes one decoded VideoFrame
+# (the caller offloads decode + pipeline drive to an executor inside it).
+FrameSink = Callable[[object], Awaitable[None]]
+# Role-broadcast hook: notify(event, pc, outcome=None); event in {"claimed","released"}.
+NotifyHook = Callable[..., None]
+
+
+async def _pump_owner_frames(track, pc, sink: FrameSink, log=None) -> None:
+    """Drain-to-latest: a reader task always overwrites `latest`, the processing
+    loop drives only the newest frame. Bounds round-trip lag and memory when the
+    pipeline is slower than the peer camera. The owner reader BLOCKS on recv()
+    with no timeout — a frame gap never evicts a live owner (the caller cancels
+    this task when the pc goes terminal)."""
+    latest = [None]
+    new_frame = asyncio.Event()
+    stopped = asyncio.Event()
+
+    async def _reader():
+        try:
+            while True:
+                latest[0] = await track.recv()
+                new_frame.set()
+        except MediaStreamError:
+            pass
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            if log:
+                log.warning("Owner track recv error: %s", exc)
+        finally:
+            stopped.set()
+            new_frame.set()  # wake the processing loop so it can exit
+
+    reader = asyncio.ensure_future(_reader())
+    try:
+        while not (stopped.is_set() and latest[0] is None):
+            await new_frame.wait()
+            new_frame.clear()
+            frame, latest[0] = latest[0], None
+            if frame is None:
+                continue
+            await sink(frame)
+    finally:
+        reader.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await reader
+
+
+async def consume_peer_input(
+    track,
+    pc,
+    ownership: InputOwnership,
+    sink: FrameSink,
+    *,
+    notify: Optional[NotifyHook] = None,
+    log=None,
+    first_frame_deadline: float = WAITER_FIRST_FRAME_DEADLINE,
+) -> None:
+    """Pull VideoFrames from a remote track and (when this peer owns the input)
+    feed them into the pipeline via `sink`. Waits for ownership while draining
+    its track view-only; the oldest waiter takes over on release."""
+    notify = notify or (lambda *a, **k: None)
+    loop = asyncio.get_running_loop()
+    seq = ownership.register_waiter(pc)
+
+    try:
+        # ── wait for ownership, draining frames so the inbound queue can't grow ──
+        got_first_frame = False
+        deadline = loop.time() + first_frame_deadline
+        announced_waiting = False
+        while not ownership.try_claim(seq, pc):
+            if not announced_waiting:
+                announced_waiting = True
+                if log:
+                    log.info("Peer %x (seq %d) waiting — view-only", id(pc), seq)
+            if got_first_frame:
+                # Delivered a frame already: a real, connected view-only peer.
+                # Block (never gap-evict); death is handled by the caller's
+                # connectionstatechange -> task cancel.
+                try:
+                    await track.recv()
+                except MediaStreamError:
+                    return
+                continue
+            remaining = deadline - loop.time()
+            if waiter_should_evict(_conn_state(pc), got_first_frame, remaining <= 0):
+                if log:
+                    log.info("Peer %x (seq %d) never connected — dropping", id(pc), seq)
+                return
+            try:
+                await asyncio.wait_for(track.recv(), timeout=max(1.0, remaining))
+                got_first_frame = True
+            except asyncio.TimeoutError:
+                continue  # re-check claim + liveness; do NOT evict a connected peer
+            except MediaStreamError:
+                return
+
+        # ── now the owner ──
+        if log:
+            log.info("Peer %x (seq %d) now drives input", id(pc), seq)
+        notify("claimed", pc)
+        await _pump_owner_frames(track, pc, sink, log=log)
+    finally:
+        outcome = ownership.release(seq, pc)
+        if log and outcome.had_owner:
+            log.info("Peer %x (seq %d) released input", id(pc), seq)
+        notify("released", pc, outcome)

--- a/src/fluxrt/webrtc/input_ownership.py
+++ b/src/fluxrt/webrtc/input_ownership.py
@@ -21,7 +21,10 @@ recv POLICY (this is the bug class that regressed in c855950):
   (owner_gap_should_release). This is NOT the c855950 blind evict — it fires
   only when a takeover candidate exists, bounding a dead owner's freeze (abrupt
   network loss keeps the pc 'connected' until ICE consent expiry ~30s) instead
-  of frozen output while a ready client sits idle.
+  of frozen output while a ready client sits idle. The yielded peer rejoins as
+  the NEWEST waiter: its track keeps being drained (aiortc decodes inbound RTP
+  into an unbounded queue whether or not anyone recv()s) and it can reclaim
+  when the slot frees.
 - A WAITER is bounded only on its FIRST frame: a peer that never delivers a frame
   AND is not in the 'connected' ICE state is a dead reconnect and is dropped after
   WAITER_FIRST_FRAME_DEADLINE. Once it has delivered a frame, it is never evicted
@@ -58,6 +61,12 @@ WAITER_FIRST_FRAME_DEADLINE = 25.0
 # CONSENT_INTERVAL=5 * CONSENT_FAILURES=6 ≈ 25-35s), which would freeze the input
 # that whole time even though a ready client is queued. This bounds the freeze to
 # ~this gap when a takeover candidate exists.
+#
+# Accepted limitation: a waiter whose network just died still counts as a
+# candidate (its state stays 'connected' until consent expiry), so a paused
+# owner can yield to a corpse. Self-healing: the yielded owner rejoins as a
+# waiter, so the corpse — silent, with a waiter present — gap-yields right back
+# within this same threshold (or consent-expires), returning the input.
 OWNER_GAP_WITH_WAITER = 8.0
 
 
@@ -183,11 +192,11 @@ async def _pump_owner_frames(
     track,
     pc,
     sink: FrameSink,
-    ownership: "InputOwnership",
+    ownership: InputOwnership,
     *,
     log=None,
     gap_release_s: float = OWNER_GAP_WITH_WAITER,
-) -> None:
+) -> bool:
     """Drain-to-latest: a reader task always overwrites `latest`, the processing
     loop drives only the newest frame. Bounds round-trip lag and memory when the
     pipeline is slower than the peer camera.
@@ -198,7 +207,11 @@ async def _pump_owner_frames(
     publisher is waiting to take over, an owner that stops delivering frames for
     >= gap_release_s yields the input (owner_gap_should_release): a dead owner's
     pc stays 'connected' until ICE consent expiry (~30s), which would otherwise
-    freeze the input while a ready client sits idle."""
+    freeze the input while a ready client sits idle.
+
+    Returns True on a gap-yield (pc may still be alive — the caller MUST keep
+    draining the track and may re-register as a waiter), False when the track
+    ended/errored."""
     loop = asyncio.get_running_loop()
     latest = [None]
     last_recv_t = [loop.time()]  # claim time is t0; a real gap counts from now
@@ -242,13 +255,14 @@ async def _pump_owner_frames(
                             id(pc),
                             gap,
                         )
-                    return  # → consume_peer_input finally → release() → handoff
+                    return True  # caller releases → handoff, then rejoins as waiter
                 continue
             new_frame.clear()
             frame, latest[0] = latest[0], None
             if frame is None:
                 continue
             await sink(frame)
+        return False  # track ended
     finally:
         reader.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -268,52 +282,68 @@ async def consume_peer_input(
 ) -> None:
     """Pull VideoFrames from a remote track and (when this peer owns the input)
     feed them into the pipeline via `sink`. Waits for ownership while draining
-    its track view-only; the oldest waiter takes over on release."""
+    its track view-only; the oldest waiter takes over on release. A gap-yielded
+    owner (silent with a waiter ready) rejoins as the NEWEST waiter and keeps
+    draining — never leave an alive track unconsumed (aiortc decodes inbound RTP
+    into an unbounded queue regardless), and it can reclaim when the slot frees."""
     notify = notify or (lambda *a, **k: None)
     loop = asyncio.get_running_loop()
-    seq = ownership.register_waiter(pc)
 
-    try:
-        # ── wait for ownership, draining frames so the inbound queue can't grow ──
-        got_first_frame = False
-        deadline = loop.time() + first_frame_deadline
-        announced_waiting = False
-        while not ownership.try_claim(seq, pc):
-            if not announced_waiting:
-                announced_waiting = True
-                if log:
-                    log.info("Peer %x (seq %d) waiting — view-only", id(pc), seq)
-            if got_first_frame:
-                # Delivered a frame already: a real, connected view-only peer.
-                # Block (never gap-evict); death is handled by the caller's
-                # connectionstatechange -> task cancel.
+    while True:
+        seq = ownership.register_waiter(pc)
+        yielded = False
+        try:
+            # ── wait for ownership, draining frames so the inbound queue can't grow ──
+            got_first_frame = False
+            deadline = loop.time() + first_frame_deadline
+            announced_waiting = False
+            while not ownership.try_claim(seq, pc):
+                if not announced_waiting:
+                    announced_waiting = True
+                    if log:
+                        log.info("Peer %x (seq %d) waiting — view-only", id(pc), seq)
+                if got_first_frame:
+                    # Delivered a frame already: a real, connected view-only peer.
+                    # Never gap-evicted; the 1s timeout only re-checks the claim so
+                    # a stalled-track waiter still takes over when the slot frees.
+                    # Death is handled by the caller's connectionstatechange ->
+                    # task cancel.
+                    try:
+                        await asyncio.wait_for(track.recv(), timeout=1.0)
+                    except asyncio.TimeoutError:
+                        continue
+                    except MediaStreamError:
+                        return
+                    continue
+                remaining = deadline - loop.time()
+                if waiter_should_evict(_conn_state(pc), got_first_frame, remaining <= 0):
+                    if log:
+                        log.info("Peer %x (seq %d) never connected — dropping", id(pc), seq)
+                    return
                 try:
-                    await track.recv()
+                    # 1s cap = claim re-check cadence for a silent waiter; the
+                    # first-frame DEADLINE (eviction) is enforced by `remaining`
+                    # above, not by this timeout.
+                    await asyncio.wait_for(track.recv(), timeout=1.0)
+                    got_first_frame = True
+                except asyncio.TimeoutError:
+                    continue  # re-check claim + liveness; do NOT evict a connected peer
                 except MediaStreamError:
                     return
-                continue
-            remaining = deadline - loop.time()
-            if waiter_should_evict(_conn_state(pc), got_first_frame, remaining <= 0):
-                if log:
-                    log.info("Peer %x (seq %d) never connected — dropping", id(pc), seq)
-                return
-            try:
-                await asyncio.wait_for(track.recv(), timeout=max(1.0, remaining))
-                got_first_frame = True
-            except asyncio.TimeoutError:
-                continue  # re-check claim + liveness; do NOT evict a connected peer
-            except MediaStreamError:
-                return
 
-        # ── now the owner ──
+            # ── now the owner ──
+            if log:
+                log.info("Peer %x (seq %d) now drives input", id(pc), seq)
+            notify("claimed", pc)
+            yielded = await _pump_owner_frames(
+                track, pc, sink, ownership, log=log, gap_release_s=owner_gap_release
+            )
+        finally:
+            outcome = ownership.release(seq, pc)
+            if log and outcome.had_owner:
+                log.info("Peer %x (seq %d) released input", id(pc), seq)
+            notify("released", pc, outcome)
+        if not yielded:
+            return
         if log:
-            log.info("Peer %x (seq %d) now drives input", id(pc), seq)
-        notify("claimed", pc)
-        await _pump_owner_frames(
-            track, pc, sink, ownership, log=log, gap_release_s=owner_gap_release
-        )
-    finally:
-        outcome = ownership.release(seq, pc)
-        if log and outcome.had_owner:
-            log.info("Peer %x (seq %d) released input", id(pc), seq)
-        notify("released", pc, outcome)
+            log.info("Peer %x rejoining as waiter after gap-yield", id(pc))

--- a/src/fluxrt/webrtc/input_ownership.py
+++ b/src/fluxrt/webrtc/input_ownership.py
@@ -12,10 +12,16 @@ is imported with a fallback) so the ownership transitions and the recv policy
 are unit-testable with fake tracks and fake peer-connection objects.
 
 recv POLICY (this is the bug class that regressed in c855950):
-- An OWNER is NEVER evicted because of a frame gap. A healthy owner legitimately
-  produces no frame for >5s (first keyframe after claiming, ICE/DTLS/TURN settle,
-  a brief stall, a paused camera). Death is detected out-of-band: the caller's
-  connectionstatechange handler cancels this task when the pc goes terminal.
+- A LONE OWNER is NEVER evicted because of a frame gap. A healthy owner
+  legitimately produces no frame for >5s (first keyframe after claiming,
+  ICE/DTLS/TURN settle, a brief stall, a paused camera). Death is detected
+  out-of-band: the caller's connectionstatechange handler cancels this task when
+  the pc goes terminal.
+- An OWNER WITH A WAITER READY does yield on a gap >= OWNER_GAP_WITH_WAITER
+  (owner_gap_should_release). This is NOT the c855950 blind evict — it fires
+  only when a takeover candidate exists, bounding a dead owner's freeze (abrupt
+  network loss keeps the pc 'connected' until ICE consent expiry ~30s) instead
+  of frozen output while a ready client sits idle.
 - A WAITER is bounded only on its FIRST frame: a peer that never delivers a frame
   AND is not in the 'connected' ICE state is a dead reconnect and is dropped after
   WAITER_FIRST_FRAME_DEADLINE. Once it has delivered a frame, it is never evicted
@@ -46,12 +52,32 @@ TERMINAL_STATES = ("failed", "closed", "disconnected")
 # as a dead reconnect (only if it is also not 'connected').
 WAITER_FIRST_FRAME_DEADLINE = 25.0
 
+# How long an OWNER may receive no frame before it yields the input — but ONLY
+# when another publisher is waiting to take over (see owner_gap_should_release).
+# A dead peer's pc stays 'connected' in aiortc until ICE consent expiry (aioice
+# CONSENT_INTERVAL=5 * CONSENT_FAILURES=6 ≈ 25-35s), which would freeze the input
+# that whole time even though a ready client is queued. This bounds the freeze to
+# ~this gap when a takeover candidate exists.
+OWNER_GAP_WITH_WAITER = 8.0
+
 
 def owner_should_release(connection_state: str) -> bool:
     """An owner is released ONLY on a terminal connection state, never on a frame
     gap. (c855950 evicted on a blind 5s recv timeout regardless of state — that
     froze healthy owners; this is the fix.)"""
     return connection_state in TERMINAL_STATES
+
+
+def owner_gap_should_release(
+    gap_s: float, other_waiters: int, threshold: float = OWNER_GAP_WITH_WAITER
+) -> bool:
+    """An owner yields the input on a receive gap ONLY when (a) the gap is at
+    least `threshold` seconds AND (b) another publisher is waiting to drive. No
+    waiter → the owner keeps the slot regardless of the gap: this is NOT a blind
+    gap-evict (the c855950 regression), it is a handoff to a ready candidate. It
+    bounds a dead owner's freeze (abrupt network loss, pc still 'connected' until
+    ICE consent expiry) to ~threshold when someone can take over."""
+    return other_waiters >= 1 and gap_s >= threshold
 
 
 def waiter_should_evict(
@@ -138,6 +164,13 @@ class InputOwnership:
         with self._lock:
             return len(self._waiters)
 
+    def num_other_waiters(self, pc) -> int:
+        """Count of registered waiters that are NOT `pc` — peers ready to take
+        over if `pc` (the current owner) releases. The owner stays registered in
+        _waiters until release, so this excludes the owner's own slot."""
+        with self._lock:
+            return sum(1 for w in self._waiters.values() if w is not pc)
+
 
 # Type of the frame sink: an async callable that consumes one decoded VideoFrame
 # (the caller offloads decode + pipeline drive to an executor inside it).
@@ -146,13 +179,29 @@ FrameSink = Callable[[object], Awaitable[None]]
 NotifyHook = Callable[..., None]
 
 
-async def _pump_owner_frames(track, pc, sink: FrameSink, log=None) -> None:
+async def _pump_owner_frames(
+    track,
+    pc,
+    sink: FrameSink,
+    ownership: "InputOwnership",
+    *,
+    log=None,
+    gap_release_s: float = OWNER_GAP_WITH_WAITER,
+) -> None:
     """Drain-to-latest: a reader task always overwrites `latest`, the processing
     loop drives only the newest frame. Bounds round-trip lag and memory when the
-    pipeline is slower than the peer camera. The owner reader BLOCKS on recv()
-    with no timeout — a frame gap never evicts a live owner (the caller cancels
-    this task when the pc goes terminal)."""
+    pipeline is slower than the peer camera.
+
+    The owner reader BLOCKS on recv() with no timeout — a frame gap never evicts
+    a *lone* owner (a paused camera / slow first keyframe is legitimate; the
+    caller cancels this task when the pc goes terminal). BUT when another
+    publisher is waiting to take over, an owner that stops delivering frames for
+    >= gap_release_s yields the input (owner_gap_should_release): a dead owner's
+    pc stays 'connected' until ICE consent expiry (~30s), which would otherwise
+    freeze the input while a ready client sits idle."""
+    loop = asyncio.get_running_loop()
     latest = [None]
+    last_recv_t = [loop.time()]  # claim time is t0; a real gap counts from now
     new_frame = asyncio.Event()
     stopped = asyncio.Event()
 
@@ -160,6 +209,7 @@ async def _pump_owner_frames(track, pc, sink: FrameSink, log=None) -> None:
         try:
             while True:
                 latest[0] = await track.recv()
+                last_recv_t[0] = loop.time()
                 new_frame.set()
         except MediaStreamError:
             pass
@@ -173,9 +223,27 @@ async def _pump_owner_frames(track, pc, sink: FrameSink, log=None) -> None:
             new_frame.set()  # wake the processing loop so it can exit
 
     reader = asyncio.ensure_future(_reader())
+    # Poll cadence: wake often enough that a crossed gap is caught within ~1s of
+    # the threshold. A healthy owner wakes on every frame and never hits this
+    # timeout — the poll only matters once frames stop.
+    poll = min(1.0, gap_release_s)
     try:
         while not (stopped.is_set() and latest[0] is None):
-            await new_frame.wait()
+            try:
+                await asyncio.wait_for(new_frame.wait(), timeout=poll)
+            except asyncio.TimeoutError:
+                gap = loop.time() - last_recv_t[0]
+                if owner_gap_should_release(
+                    gap, ownership.num_other_waiters(pc), gap_release_s
+                ):
+                    if log:
+                        log.info(
+                            "Owner %x silent %.1fs with a waiter ready — yielding input",
+                            id(pc),
+                            gap,
+                        )
+                    return  # → consume_peer_input finally → release() → handoff
+                continue
             new_frame.clear()
             frame, latest[0] = latest[0], None
             if frame is None:
@@ -196,6 +264,7 @@ async def consume_peer_input(
     notify: Optional[NotifyHook] = None,
     log=None,
     first_frame_deadline: float = WAITER_FIRST_FRAME_DEADLINE,
+    owner_gap_release: float = OWNER_GAP_WITH_WAITER,
 ) -> None:
     """Pull VideoFrames from a remote track and (when this peer owns the input)
     feed them into the pipeline via `sink`. Waits for ownership while draining
@@ -240,7 +309,9 @@ async def consume_peer_input(
         if log:
             log.info("Peer %x (seq %d) now drives input", id(pc), seq)
         notify("claimed", pc)
-        await _pump_owner_frames(track, pc, sink, log=log)
+        await _pump_owner_frames(
+            track, pc, sink, ownership, log=log, gap_release_s=owner_gap_release
+        )
     finally:
         outcome = ownership.release(seq, pc)
         if log and outcome.had_owner:

--- a/src/fluxrt/webrtc/proc.py
+++ b/src/fluxrt/webrtc/proc.py
@@ -1,0 +1,65 @@
+"""
+Bounded subprocess teardown for the spawned inference / output-scheduler
+children.
+
+Why this exists: a CUDA-wedged child can survive even SIGKILL+join for a while
+(uninterruptible driver syscall, D state). multiprocessing's atexit
+_exit_function then joins every still-registered non-daemon child with NO
+timeout — a permanent shutdown hang requiring a manual kill. After the kill
+escalation we force one more SIGKILL and DISCARD the survivor from
+multiprocessing.process._children so that atexit join can never block on it.
+
+Torch-free and import-light so the escalation ladder is unit-testable with a
+real, deliberately-wedged multiprocessing child (no GPU).
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+
+
+def reap_process(proc, join_timeouts: tuple[float, float, float] = (5.0, 3.0, 2.0)) -> bool:
+    """Escalate join -> terminate -> kill on `proc`, bounded by `join_timeouts`.
+    The caller must already have signalled the child to stop (e.g. flipped its
+    `running` Value) so the first join can succeed gracefully.
+
+    Returns True if the process is confirmed dead, False if it outlived even the
+    final SIGKILL (in which case it has been detached from multiprocessing's
+    child registry so interpreter-exit can't block joining it).
+    """
+    if proc is None:
+        return True
+
+    t_join, t_term, t_kill = join_timeouts
+
+    proc.join(timeout=t_join)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join(timeout=t_term)
+    if proc.is_alive():
+        proc.kill()
+        proc.join(timeout=t_kill)
+
+    if proc.is_alive():
+        # Survived SIGKILL+join (typically a D-state CUDA syscall). Re-signal and
+        # DETACH from multiprocessing._children so the no-timeout atexit join
+        # can't hang the parent and leave an orphaned GPU process.
+        pid = getattr(proc, "pid", None)
+        if pid is not None:
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except Exception:
+                pass
+        _discard_from_children(proc)
+        return False
+    return True
+
+
+def _discard_from_children(proc) -> None:
+    try:
+        import multiprocessing.process as _mpp
+
+        _mpp._children.discard(proc)
+    except Exception:
+        pass

--- a/src/fluxrt/webrtc/stats.py
+++ b/src/fluxrt/webrtc/stats.py
@@ -1,0 +1,36 @@
+"""Connection-pool stats for /healthz.
+
+Torch-free and pure so it is unit-tested off-GPU: given the connectionState of
+every peer in the pool, summarise total / active / per-state counts.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+# aiortc RTCPeerConnection.connectionState values.
+_KNOWN_STATES = ("new", "connecting", "connected", "disconnected", "failed", "closed")
+
+
+def connection_pool_stats(states) -> dict:
+    """Summarise the peer-connection pool.
+
+    Args:
+        states: iterable of per-peer connectionState strings (None -> "unknown").
+
+    Returns:
+        {"total": int, "active": int, "by_state": {state: count, ...}} where
+        `active` counts peers in the "connected" state. by_state is sorted with
+        known states first (in lifecycle order) then any extras alphabetically.
+    """
+    counts = Counter((s or "unknown") for s in states)
+    order = {s: i for i, s in enumerate(_KNOWN_STATES)}
+    by_state = {
+        s: counts[s]
+        for s in sorted(counts, key=lambda s: (order.get(s, len(order)), s))
+    }
+    return {
+        "total": sum(counts.values()),
+        "active": counts.get("connected", 0),
+        "by_state": by_state,
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Make scripts/ (batch_render, batch_routes) importable without installing them.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))

--- a/tests/test_batch_render.py
+++ b/tests/test_batch_render.py
@@ -326,6 +326,15 @@ def test_live_prompt_steering_forwards_to_active_proc():
     assert mgr.set_prompt("noop") is False  # no active job → not forwarded
 
 
+def test_latest_frame_tracked_for_preview():
+    stubs = []
+    mgr = _manager(stubs)
+    assert mgr.latest_jpeg() is None  # nothing rendered yet (no cv2 needed)
+    job = mgr.submit(make_mp4_bytes(n_frames=3), prompt="a", seed=1, steps=2, fps=None)
+    assert wait_until(lambda: mgr.get(job.id).state == "done")
+    assert mgr._latest_frame is not None  # tracks the last rendered frame
+
+
 def test_preflight_rejection_blocks_submit():
     stubs = []
     mgr = _manager(stubs)

--- a/tests/test_batch_render.py
+++ b/tests/test_batch_render.py
@@ -1,0 +1,283 @@
+"""GPU-free tests for the offline batch render: PyAV decode/encode round-trip and
+the JobManager state machine against a STUB processor (no CUDA, no torch)."""
+
+import os
+import tempfile
+import time
+
+import av
+import numpy as np
+import pytest
+
+from batch_render import BatchJobManager, Mp4Encoder, decode_video
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+def make_mp4(path, n_frames=6, w=64, h=48, fps=10):
+    """Write a synthetic CFR mp4 with `n_frames` distinct frames."""
+    container = av.open(path, mode="w")
+    stream = container.add_stream("libx264", rate=fps)
+    stream.width, stream.height, stream.pix_fmt = w, h, "yuv420p"
+    for i in range(n_frames):
+        arr = np.full((h, w, 3), (i * 37) % 256, dtype=np.uint8)
+        for pkt in stream.encode(av.VideoFrame.from_ndarray(arr, format="rgb24")):
+            container.mux(pkt)
+    for pkt in stream.encode():
+        container.mux(pkt)
+    container.close()
+
+
+def make_mp4_bytes(**kw):
+    with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+        path = f.name
+    try:
+        make_mp4(path, **kw)
+        with open(path, "rb") as fh:
+            return fh.read()
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def count_frames(path):
+    c = av.open(path)
+    try:
+        return sum(1 for _ in c.decode(c.streams.video[0]))
+    finally:
+        c.close()
+
+
+class StubProcessor:
+    """Stand-in for a batch StreamProcessor. Records lifecycle/config. By default
+    echoes frames; `marker=True` emits a per-frame solid value (idx*8) so order is
+    verifiable through the lossy codec; `out_scale` emits an upscaled output so the
+    encoder's output-derived sizing is exercised."""
+
+    def __init__(self, cfg, per_frame_sleep=0.0, fail=False, marker=False, out_scale=1):
+        self.cfg = cfg
+        self.per_frame_sleep = per_frame_sleep
+        self.fail = fail
+        self.marker = marker
+        self.out_scale = out_scale
+        self.started = self.stopped = False
+        self.prompt = self.seed = self.steps = None
+        self.n_frames = 0
+
+    def start(self):
+        self.started = True
+
+    def is_ready(self):
+        return True
+
+    def worker_alive(self):
+        return True
+
+    def set_prompt(self, p):
+        self.prompt = p
+
+    def set_seed(self, s):
+        self.seed = s
+
+    def set_steps(self, s):
+        self.steps = s
+
+    def submit_frame(self, rgb):
+        if self.per_frame_sleep:
+            time.sleep(self.per_frame_sleep)
+        if self.fail:
+            raise RuntimeError("boom")
+        idx = self.n_frames
+        self.n_frames += 1
+        h, w = rgb.shape[:2]
+        if self.marker:
+            return np.full((h * self.out_scale, w * self.out_scale, 3), (idx * 8) % 256, dtype=np.uint8)
+        if self.out_scale != 1:
+            return np.zeros((h * self.out_scale, w * self.out_scale, 3), dtype=np.uint8)
+        return rgb.copy()  # echo: 1:1, preserves count
+
+    def stop(self):
+        self.stopped = True
+
+
+def wait_until(pred, timeout=10.0, interval=0.02):
+    end = time.time() + timeout
+    while time.time() < end:
+        if pred():
+            return True
+        time.sleep(interval)
+    return False
+
+
+# ── PyAV IO ───────────────────────────────────────────────────────────────────
+def test_decode_then_encode_preserves_count_and_fps(tmp_path):
+    src = str(tmp_path / "in.mp4")
+    make_mp4(src, n_frames=8, fps=12)
+    frames, fps = decode_video(src)
+    assert len(frames) == 8
+    assert frames[0].shape == (48, 64, 3) and frames[0].dtype == np.uint8
+    assert round(fps) == 12
+
+    out = str(tmp_path / "out.mp4")
+    enc = Mp4Encoder(out, fps, frames[0].shape[1], frames[0].shape[0])
+    for fr in frames:
+        enc.write(fr)
+    enc.close()
+    enc.close()  # idempotent
+    assert count_frames(out) == 8
+
+
+# ── JobManager ────────────────────────────────────────────────────────────────
+def _manager(stub_holder, base_config=None, **stub_kw):
+    def make(cfg):
+        stub = StubProcessor(cfg, **stub_kw)
+        stub_holder.append(stub)
+        return stub
+    base = base_config if base_config is not None else {"resolution": {"height": 48, "width": 64}}
+    return BatchJobManager(base_config=base, make_processor=make)
+
+
+def _video_rate(path):
+    c = av.open(path)
+    try:
+        return c.streams.video[0].average_rate
+    finally:
+        c.close()
+
+
+def test_job_happy_path_renders_1to1(tmp_path):
+    stubs = []
+    mgr = _manager(stubs)
+    job = mgr.submit(make_mp4_bytes(n_frames=6, fps=10), prompt="cat", seed=7, steps=2, fps=None)
+    assert wait_until(lambda: mgr.get(job.id).state in ("done", "error"))
+    j = mgr.get(job.id)
+    assert j.state == "done", j.error
+    assert j.frames_total == 6 and j.frames_done == 6
+    assert count_frames(j.out_path) == 6           # exactly one output per input
+    assert stubs[0].prompt == "cat" and stubs[0].seed == 7 and stubs[0].steps == 2
+    assert stubs[0].started and stubs[0].stopped   # parked after the job
+
+
+def test_second_submit_rejected_while_running():
+    stubs = []
+    mgr = _manager(stubs, per_frame_sleep=0.05)
+    j1 = mgr.submit(make_mp4_bytes(n_frames=20), prompt="a", seed=1, steps=2, fps=None)
+    assert wait_until(lambda: mgr.get(j1.id).state == "running")
+    with pytest.raises(RuntimeError):
+        mgr.submit(make_mp4_bytes(n_frames=5), prompt="b", seed=1, steps=2, fps=None)
+    mgr.cancel(j1.id)
+    assert wait_until(lambda: mgr.get(j1.id).state in ("canceled", "done"))
+
+
+def test_cancel_midjob_sets_canceled_and_parks():
+    stubs = []
+    mgr = _manager(stubs, per_frame_sleep=0.05)
+    job = mgr.submit(make_mp4_bytes(n_frames=40), prompt="a", seed=1, steps=2, fps=None)
+    assert wait_until(lambda: mgr.get(job.id).state == "running")
+    mgr.cancel(job.id)
+    assert wait_until(lambda: mgr.get(job.id).state == "canceled")
+    assert wait_until(lambda: stubs[0].stopped)          # processor torn down
+    assert mgr.active_job_id() is None                   # slot freed for the next job
+
+
+def test_processor_error_sets_error_and_parks():
+    stubs = []
+    mgr = _manager(stubs, fail=True)
+    job = mgr.submit(make_mp4_bytes(n_frames=4), prompt="a", seed=1, steps=2, fps=None)
+    assert wait_until(lambda: mgr.get(job.id).state == "error")
+    assert "boom" in mgr.get(job.id).error
+    assert wait_until(lambda: stubs[0].stopped)
+    assert mgr.active_job_id() is None
+
+
+def test_empty_video_errors_without_processor():
+    stubs = []
+    mgr = _manager(stubs)
+    job = mgr.submit(b"not a video", prompt="a", seed=1, steps=2, fps=None)
+    assert wait_until(lambda: mgr.get(job.id).state == "error")
+    assert mgr.active_job_id() is None
+
+
+def test_fps_override_and_source_fallback():
+    stubs = []
+    mgr = _manager(stubs)
+    # explicit override wins over the 10 fps source
+    j1 = mgr.submit(make_mp4_bytes(n_frames=5, fps=10), prompt="a", seed=1, steps=2, fps=24)
+    assert wait_until(lambda: mgr.get(j1.id).state in ("done", "error"))
+    assert mgr.get(j1.id).state == "done", mgr.get(j1.id).error
+    assert round(float(_video_rate(mgr.get(j1.id).out_path))) == 24
+    # None -> the source rate is used
+    j2 = mgr.submit(make_mp4_bytes(n_frames=5, fps=10), prompt="a", seed=1, steps=2, fps=None)
+    assert wait_until(lambda: mgr.get(j2.id).state == "done")
+    assert round(float(_video_rate(mgr.get(j2.id).out_path))) == 10
+
+
+def test_batch_config_overrides_and_isolates_base():
+    base = {
+        "resolution": {"height": 48, "width": 64},
+        "interpolation_exp": 3,
+        "logging": True,
+        "lip_transfer": {"enable": True},
+    }
+    stubs = []
+    mgr = _manager(stubs, base_config=base)
+    job = mgr.submit(make_mp4_bytes(n_frames=3), prompt="a", seed=1, steps=2, fps=None)
+    assert wait_until(lambda: mgr.get(job.id).state == "done")
+    cfg = stubs[0].cfg
+    assert cfg["batch_mode"] is True
+    assert cfg["interpolation_exp"] == 0
+    assert cfg["logging"] is False
+    assert cfg["lip_transfer"]["enable"] is False
+    # the live base config (incl. its nested dict) is untouched
+    assert base["interpolation_exp"] == 3
+    assert base["logging"] is True
+    assert base["lip_transfer"]["enable"] is True
+
+
+def test_encoder_sized_from_output_not_input():
+    stubs = []
+    mgr = _manager(stubs, out_scale=2)  # 64x48 input -> 128x96 output
+    job = mgr.submit(make_mp4_bytes(n_frames=4, w=64, h=48), prompt="a", seed=1, steps=2, fps=None)
+    assert wait_until(lambda: mgr.get(job.id).state == "done"), mgr.get(job.id).error
+    c = av.open(mgr.get(job.id).out_path)
+    try:
+        st = c.streams.video[0]
+        assert (st.codec_context.width, st.codec_context.height) == (128, 96)
+    finally:
+        c.close()
+
+
+def test_output_order_preserved():
+    stubs = []
+    mgr = _manager(stubs, marker=True)  # frame k -> solid value k*8
+    job = mgr.submit(make_mp4_bytes(n_frames=10), prompt="a", seed=1, steps=2, fps=None)
+    assert wait_until(lambda: mgr.get(job.id).state == "done")
+    c = av.open(mgr.get(job.id).out_path)
+    means = [float(f.to_ndarray(format="rgb24").mean()) for f in c.decode(c.streams.video[0])]
+    c.close()
+    assert len(means) == 10
+    # strictly increasing means => frames came out in submission order (codec-noise tolerant)
+    assert all(b > a for a, b in zip(means, means[1:])), means
+
+
+def test_canceled_job_leaves_no_output_file():
+    stubs = []
+    mgr = _manager(stubs, per_frame_sleep=0.05)
+    job = mgr.submit(make_mp4_bytes(n_frames=40), prompt="a", seed=1, steps=2, fps=None)
+    assert wait_until(lambda: mgr.get(job.id).state == "running")
+    mgr.cancel(job.id)
+    assert wait_until(lambda: mgr.get(job.id).state == "canceled")
+    j = mgr.get(job.id)
+    assert not (j.out_path and os.path.exists(j.out_path))  # partial cleaned up
+
+
+def test_preflight_rejection_blocks_submit():
+    stubs = []
+    mgr = _manager(stubs)
+
+    def deny():
+        raise RuntimeError("insufficient VRAM")
+
+    mgr._preflight = deny
+    with pytest.raises(RuntimeError, match="VRAM"):
+        mgr.submit(make_mp4_bytes(n_frames=3), prompt="a", seed=1, steps=2, fps=None)
+    assert mgr.active_job_id() is None  # rejected before claiming the slot

--- a/tests/test_batch_render.py
+++ b/tests/test_batch_render.py
@@ -62,6 +62,7 @@ class StubProcessor:
         self.frames_per_input = frames_per_input  # simulate RIFE (>1 = interpolation)
         self.started = self.stopped = False
         self.prompt = self.seed = self.steps = None
+        self.travel = None
         self.n_frames = 0
 
     def start(self):
@@ -81,6 +82,9 @@ class StubProcessor:
 
     def set_steps(self, s):
         self.steps = s
+
+    def start_prompt_travel(self, text, frames=48, mode="slerp"):
+        self.travel = (text, frames, mode)
 
     def submit_frame(self, rgb):
         if self.per_frame_sleep:
@@ -306,6 +310,20 @@ def test_interp_clamped_to_0_4():
     job = mgr.submit(make_mp4_bytes(n_frames=2), prompt="a", seed=1, steps=2, fps=None, interp=9)
     assert wait_until(lambda: mgr.get(job.id).state == "done")
     assert mgr.get(job.id).interp == 4  # clamped
+
+
+def test_live_prompt_steering_forwards_to_active_proc():
+    stubs = []
+    mgr = _manager(stubs, per_frame_sleep=0.05)
+    job = mgr.submit(make_mp4_bytes(n_frames=40), prompt="start", seed=1, steps=2, fps=None)
+    assert wait_until(lambda: mgr.get(job.id).state == "running")
+    assert mgr.set_prompt("steered") is True
+    assert wait_until(lambda: stubs[0].prompt == "steered")
+    assert mgr.start_prompt_travel("morph", frames=10, mode="slerp") is True
+    assert wait_until(lambda: stubs[0].travel == ("morph", 10, "slerp"))
+    mgr.cancel(job.id)
+    assert wait_until(lambda: mgr.active_job_id() is None)
+    assert mgr.set_prompt("noop") is False  # no active job → not forwarded
 
 
 def test_preflight_rejection_blocks_submit():

--- a/tests/test_batch_render.py
+++ b/tests/test_batch_render.py
@@ -224,11 +224,11 @@ def test_batch_config_overrides_and_isolates_base():
     }
     stubs = []
     mgr = _manager(stubs, base_config=base)
-    job = mgr.submit(make_mp4_bytes(n_frames=3), prompt="a", seed=1, steps=2, fps=None)
+    job = mgr.submit(make_mp4_bytes(n_frames=3), prompt="a", seed=1, steps=2, fps=None, interp=0)
     assert wait_until(lambda: mgr.get(job.id).state == "done")
     cfg = stubs[0].cfg
     assert cfg["batch_mode"] is True
-    assert cfg["interpolation_exp"] == 0
+    assert cfg["interpolation_exp"] == 0  # explicit interp=0 overrides the base's 3
     assert cfg["logging"] is False
     assert cfg["lip_transfer"]["enable"] is False
     # the live base config (incl. its nested dict) is untouched
@@ -284,6 +284,20 @@ def test_interpolation_multiplies_frames_and_fps():
     assert stubs[0].cfg["interpolation_exp"] == 1          # interp threaded to the batch config
     assert count_frames(j.out_path) == 10                  # 2 output frames per input
     assert round(float(_video_rate(j.out_path))) == 20     # source 10 fps × 2**1
+
+
+def test_interp_inherits_server_default_when_unset():
+    base = {"resolution": {"height": 48, "width": 64}, "interpolation_exp": 2}
+    stubs = []
+    mgr = _manager(stubs, base_config=base)
+    # None → inherit the server's interpolation_exp (the --interp flag)
+    j1 = mgr.submit(make_mp4_bytes(n_frames=2), prompt="a", seed=1, steps=2, fps=None, interp=None)
+    assert wait_until(lambda: mgr.get(j1.id).state in ("done", "error"))
+    assert mgr.get(j1.id).interp == 2
+    # explicit value overrides the server default
+    j2 = mgr.submit(make_mp4_bytes(n_frames=2), prompt="a", seed=1, steps=2, fps=None, interp=0)
+    assert wait_until(lambda: mgr.get(j2.id).state in ("done", "error"))
+    assert mgr.get(j2.id).interp == 0
 
 
 def test_interp_clamped_to_0_4():

--- a/tests/test_batch_render.py
+++ b/tests/test_batch_render.py
@@ -53,12 +53,13 @@ class StubProcessor:
     verifiable through the lossy codec; `out_scale` emits an upscaled output so the
     encoder's output-derived sizing is exercised."""
 
-    def __init__(self, cfg, per_frame_sleep=0.0, fail=False, marker=False, out_scale=1):
+    def __init__(self, cfg, per_frame_sleep=0.0, fail=False, marker=False, out_scale=1, frames_per_input=1):
         self.cfg = cfg
         self.per_frame_sleep = per_frame_sleep
         self.fail = fail
         self.marker = marker
         self.out_scale = out_scale
+        self.frames_per_input = frames_per_input  # simulate RIFE (>1 = interpolation)
         self.started = self.stopped = False
         self.prompt = self.seed = self.steps = None
         self.n_frames = 0
@@ -90,10 +91,13 @@ class StubProcessor:
         self.n_frames += 1
         h, w = rgb.shape[:2]
         if self.marker:
-            return np.full((h * self.out_scale, w * self.out_scale, 3), (idx * 8) % 256, dtype=np.uint8)
-        if self.out_scale != 1:
-            return np.zeros((h * self.out_scale, w * self.out_scale, 3), dtype=np.uint8)
-        return rgb.copy()  # echo: 1:1, preserves count
+            base = np.full((h * self.out_scale, w * self.out_scale, 3), (idx * 8) % 256, dtype=np.uint8)
+        elif self.out_scale != 1:
+            base = np.zeros((h * self.out_scale, w * self.out_scale, 3), dtype=np.uint8)
+        else:
+            base = rgb.copy()
+        # submit_frame returns a LIST (1 for 1:1, frames_per_input to simulate RIFE).
+        return [base.copy() for _ in range(self.frames_per_input)]
 
     def stop(self):
         self.stopped = True
@@ -268,6 +272,26 @@ def test_canceled_job_leaves_no_output_file():
     assert wait_until(lambda: mgr.get(job.id).state == "canceled")
     j = mgr.get(job.id)
     assert not (j.out_path and os.path.exists(j.out_path))  # partial cleaned up
+
+
+def test_interpolation_multiplies_frames_and_fps():
+    stubs = []
+    mgr = _manager(stubs, frames_per_input=2)  # simulate 2x RIFE (interp=1)
+    job = mgr.submit(make_mp4_bytes(n_frames=5, fps=10), prompt="a", seed=1, steps=2, fps=None, interp=1)
+    assert wait_until(lambda: mgr.get(job.id).state == "done"), mgr.get(job.id).error
+    j = mgr.get(job.id)
+    assert j.frames_total == 5 and j.frames_done == 5     # progress counts INPUTS
+    assert stubs[0].cfg["interpolation_exp"] == 1          # interp threaded to the batch config
+    assert count_frames(j.out_path) == 10                  # 2 output frames per input
+    assert round(float(_video_rate(j.out_path))) == 20     # source 10 fps × 2**1
+
+
+def test_interp_clamped_to_0_4():
+    stubs = []
+    mgr = _manager(stubs)
+    job = mgr.submit(make_mp4_bytes(n_frames=2), prompt="a", seed=1, steps=2, fps=None, interp=9)
+    assert wait_until(lambda: mgr.get(job.id).state == "done")
+    assert mgr.get(job.id).interp == 4  # clamped
 
 
 def test_preflight_rejection_blocks_submit():

--- a/tests/test_batch_routes.py
+++ b/tests/test_batch_routes.py
@@ -1,0 +1,113 @@
+"""GPU-free tests for the batch FastAPI routes (batch_routes.make_batch_router)
+wired to a real BatchJobManager + a STUB processor. No CUDA / torch."""
+
+import time
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import batch_routes
+from batch_render import BatchJobManager
+from batch_routes import make_batch_router
+from test_batch_render import StubProcessor, make_mp4_bytes, count_frames, wait_until
+
+
+def _client(enabled=True, per_frame_sleep=0.0):
+    stubs = []
+
+    def make(cfg):
+        s = StubProcessor(cfg, per_frame_sleep=per_frame_sleep)
+        stubs.append(s)
+        return s
+
+    mgr = BatchJobManager(base_config={"resolution": {"height": 48, "width": 64}}, make_processor=make)
+    app = FastAPI()
+    app.include_router(make_batch_router(lambda: mgr, lambda: enabled, lambda: "default"))
+    return TestClient(app), mgr, stubs
+
+
+def _post(client, mp4, seed=5, steps=2, prompt=""):
+    return client.post(
+        "/batch/jobs",
+        data={"seed": seed, "steps": steps, "prompt": prompt},
+        files={"video": ("in.mp4", mp4, "video/mp4")},
+    )
+
+
+def test_disabled_returns_503():
+    client, _, _ = _client(enabled=False)
+    r = _post(client, make_mp4_bytes(n_frames=3))
+    assert r.status_code == 503
+
+
+def test_full_job_flow_post_poll_result(tmp_path):
+    client, mgr, stubs = _client()
+    r = _post(client, make_mp4_bytes(n_frames=5, fps=10), prompt="cat")
+    assert r.status_code == 202
+    job_id = r.json()["id"]
+
+    # poll status until done
+    deadline = time.time() + 10
+    state = None
+    while time.time() < deadline:
+        s = client.get(f"/batch/jobs/{job_id}")
+        assert s.status_code == 200
+        state = s.json()["state"]
+        if state in ("done", "error"):
+            break
+        time.sleep(0.05)
+    assert state == "done"
+    assert stubs[0].prompt == "cat"  # default not used when prompt provided
+
+    res = client.get(f"/batch/jobs/{job_id}/result")
+    assert res.status_code == 200
+    assert res.headers["content-type"] == "video/mp4"
+    out = tmp_path / "out.mp4"
+    out.write_bytes(res.content)
+    assert count_frames(str(out)) == 5  # 1:1
+
+
+def test_default_prompt_used_when_blank():
+    client, mgr, stubs = _client()
+    r = _post(client, make_mp4_bytes(n_frames=3), prompt="")
+    assert r.status_code == 202
+    job_id = r.json()["id"]
+    deadline = time.time() + 10
+    while time.time() < deadline and mgr.get(job_id).state not in ("done", "error"):
+        time.sleep(0.05)
+    assert stubs[0].prompt == "default"
+
+
+def test_unknown_job_404():
+    client, _, _ = _client()
+    assert client.get("/batch/jobs/nope").status_code == 404
+    assert client.delete("/batch/jobs/nope").status_code == 404
+
+
+def test_result_before_done_is_409():
+    client, mgr, stubs = _client(per_frame_sleep=0.05)
+    r = _post(client, make_mp4_bytes(n_frames=30))
+    job_id = r.json()["id"]
+    # running → result not ready (bounded wait; fail loudly if it never gets there)
+    assert wait_until(lambda: mgr.get(job_id).state in ("running", "done", "error"))
+    assert mgr.get(job_id).state == "running", mgr.get(job_id).error
+    assert client.get(f"/batch/jobs/{job_id}/result").status_code == 409
+    assert client.delete(f"/batch/jobs/{job_id}").json() == {"ok": True}
+
+
+def test_second_job_while_running_409():
+    client, mgr, stubs = _client(per_frame_sleep=0.05)
+    r1 = _post(client, make_mp4_bytes(n_frames=30))
+    jid = r1.json()["id"]
+    assert wait_until(lambda: mgr.get(jid).state in ("running", "done", "error"))
+    assert mgr.get(jid).state == "running", mgr.get(jid).error
+    r2 = _post(client, make_mp4_bytes(n_frames=3))
+    assert r2.status_code == 409
+    client.delete(f"/batch/jobs/{jid}")
+
+
+def test_oversize_upload_413(monkeypatch):
+    monkeypatch.setattr(batch_routes, "_MAX_UPLOAD_BYTES", 1024)  # 1 KB cap
+    client, _, _ = _client()
+    r = _post(client, make_mp4_bytes(n_frames=20))  # > 1 KB
+    assert r.status_code == 413

--- a/tests/test_batch_routes.py
+++ b/tests/test_batch_routes.py
@@ -84,6 +84,13 @@ def test_unknown_job_404():
     assert client.delete("/batch/jobs/nope").status_code == 404
 
 
+def test_preview_503_when_disabled_404_when_no_frame():
+    client, _, _ = _client(enabled=False)
+    assert client.get("/batch/preview.jpg").status_code == 503
+    client2, _, _ = _client()
+    assert client2.get("/batch/preview.jpg").status_code == 404  # nothing rendered yet
+
+
 def test_result_before_done_is_409():
     client, mgr, stubs = _client(per_frame_sleep=0.05)
     r = _post(client, make_mp4_bytes(n_frames=30))

--- a/tests/webrtc/_child_targets.py
+++ b/tests/webrtc/_child_targets.py
@@ -1,0 +1,11 @@
+"""Top-level (picklable) child entry points for the reap tests under spawn."""
+
+import signal
+import time
+
+
+def busy_child(ignore_sigterm=False):
+    if ignore_sigterm:
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    while True:
+        time.sleep(0.05)

--- a/tests/webrtc/conftest.py
+++ b/tests/webrtc/conftest.py
@@ -1,0 +1,35 @@
+"""
+Make src/fluxrt/webrtc/* importable on a laptop WITHOUT torch.
+
+src/fluxrt/__init__.py does `from .stream_processor import *`, which imports
+torch/diffusers. To unit-test the torch-free webrtc submodules we install a fake
+top-level `fluxrt` package whose __path__ points at the real src/fluxrt, so
+`import fluxrt.webrtc.input_ownership` loads the real submodule file but never
+runs the heavy package __init__.
+"""
+
+import pathlib
+import sys
+import types
+
+_HERE = pathlib.Path(__file__).resolve()
+_TESTS_DIR = _HERE.parent
+_REPO = _HERE.parents[2]
+_SRC = _REPO / "src"
+
+for _p in (str(_SRC), str(_TESTS_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+# Torch-free shim for the `fluxrt` package.
+_pkg = types.ModuleType("fluxrt")
+_pkg.__path__ = [str(_SRC / "fluxrt")]
+sys.modules["fluxrt"] = _pkg
+
+
+def test_no_torch_leaked():
+    """Guard: importing the webrtc modules must not drag in torch."""
+    import fluxrt.webrtc.input_ownership  # noqa: F401
+    import fluxrt.webrtc.proc  # noqa: F401
+
+    assert "torch" not in sys.modules, "a real fluxrt import leaked torch into the harness"

--- a/tests/webrtc/pytest.ini
+++ b/tests/webrtc/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+asyncio_mode = auto
+testpaths = .
+addopts = -ra

--- a/tests/webrtc/test_consume_peer_input.py
+++ b/tests/webrtc/test_consume_peer_input.py
@@ -1,0 +1,150 @@
+"""Async integration tests for consume_peer_input / the owner pump.
+
+Drives the real coroutine with a fake track + a fake peer-connection (just a
+`connectionState` attribute) and a recording sink. No aiortc transport, no GPU.
+"""
+
+import asyncio
+
+import pytest
+
+from fluxrt.webrtc.input_ownership import (
+    InputOwnership,
+    MediaStreamError,
+    consume_peer_input,
+)
+
+
+class FakeTrack:
+    """recv() yields queued frames (optionally with a gap), then ends; or blocks
+    forever (`never=True`) to simulate a registered-but-silent track."""
+
+    def __init__(self, frames=(), gap=0.0, ends=True, never=False):
+        self._frames = list(frames)
+        self._gap = gap
+        self._ends = ends
+        self._never = never
+        self.recv_calls = 0
+
+    async def recv(self):
+        self.recv_calls += 1
+        if self._never:
+            await asyncio.Event().wait()  # never returns
+        if self._gap:
+            await asyncio.sleep(self._gap)
+        if self._frames:
+            return self._frames.pop(0)
+        if self._ends:
+            raise MediaStreamError("ended")
+        await asyncio.Event().wait()
+
+
+class FakePC:
+    def __init__(self, state="connected"):
+        self.connectionState = state
+
+
+def _sink_recorder():
+    got = []
+
+    async def sink(frame):
+        got.append(frame)
+
+    return got, sink
+
+
+async def test_owner_drives_frames_then_releases_on_track_end():
+    own = InputOwnership(has_server_camera=True)
+    track = FakeTrack(frames=["f1", "f2", "f3"], gap=0.01, ends=True)
+    pc = FakePC("connected")
+    got, sink = _sink_recorder()
+
+    await asyncio.wait_for(consume_peer_input(track, pc, own, sink), timeout=3)
+
+    assert got == ["f1", "f2", "f3"]
+    assert own.is_active() is False
+    assert own.num_waiters() == 0
+
+
+async def test_owner_survives_long_frame_gap_no_false_evict():
+    # The behaviour c855950 broke: a connected owner with a gap is NOT evicted.
+    own = InputOwnership(has_server_camera=False)
+    track = FakeTrack(frames=["f1", "f2"], gap=0.2, ends=True)
+    pc = FakePC("connected")
+    got, sink = _sink_recorder()
+
+    await asyncio.wait_for(consume_peer_input(track, pc, own, sink), timeout=3)
+    assert got == ["f1", "f2"]  # both delivered across the gaps, owner never dropped
+
+
+async def test_silent_dead_waiter_is_evicted():
+    own = InputOwnership()
+    # An existing owner so the new peer must wait.
+    a = FakePC("connected")
+    sa = own.register_waiter(a)
+    assert own.try_claim(sa, a)
+
+    silent = FakeTrack(never=True)
+    pc_b = FakePC("failed")  # never connected
+    _, sink = _sink_recorder()
+
+    # Should evict within ~the deadline and return (not hang).
+    await asyncio.wait_for(
+        consume_peer_input(silent, pc_b, own, sink, first_frame_deadline=0.2),
+        timeout=2,
+    )
+    assert own.num_waiters() == 1  # only A remains
+    assert own.owner_is(a) is True
+
+
+async def test_silent_but_connected_waiter_is_not_evicted():
+    own = InputOwnership()
+    a = FakePC("connected")
+    sa = own.register_waiter(a)
+    own.try_claim(sa, a)
+
+    silent = FakeTrack(never=True)
+    pc_b = FakePC("connected")  # connected, just slow — must NOT be dropped
+    _, sink = _sink_recorder()
+
+    task = asyncio.ensure_future(
+        consume_peer_input(silent, pc_b, own, sink, first_frame_deadline=0.2)
+    )
+    await asyncio.sleep(0.5)  # well past the deadline
+    assert not task.done(), "a connected waiter must not be gap-evicted"
+    assert own.num_waiters() == 2
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+async def test_oldest_waiter_takes_over_when_owner_releases():
+    own = InputOwnership(has_server_camera=False)
+    a = FakePC("connected")
+    sa = own.register_waiter(a)
+    own.try_claim(sa, a)  # A owns
+
+    # Long-running stream so B is still alive (not drained out) when A leaves.
+    track_b = FakeTrack(frames=[f"b{i}" for i in range(200)], gap=0.02, ends=False)
+    pc_b = FakePC("connected")
+    got, sink = _sink_recorder()
+    task = asyncio.ensure_future(consume_peer_input(track_b, pc_b, own, sink))
+
+    await asyncio.sleep(0.1)  # B drains view-only, cannot claim while A owns
+    assert own.owner_is(a) is True
+    assert not own.owner_is(pc_b)
+
+    own.release(sa, a)  # A leaves
+    await asyncio.wait_for(_wait(lambda: own.owner_is(pc_b)), timeout=2)
+    await asyncio.wait_for(_wait(lambda: len(got) > 0), timeout=2)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert own.num_waiters() == 0  # B's finally released its slot on cancel
+
+
+async def _wait(pred, interval=0.01):
+    while not pred():
+        await asyncio.sleep(interval)

--- a/tests/webrtc/test_consume_peer_input.py
+++ b/tests/webrtc/test_consume_peer_input.py
@@ -148,7 +148,8 @@ async def test_oldest_waiter_takes_over_when_owner_releases():
 async def test_owner_gap_with_waiter_yields_input():
     # Owner A stops delivering frames while publisher B waits. A must yield within
     # ~the gap so B takes over — NOT wait out ICE consent expiry (~30s). This is
-    # the fast dead-owner path (V3).
+    # the fast dead-owner path (V3). A's task does NOT finish: it rejoins as the
+    # newest waiter (drains its track, can reclaim later — V9).
     own = InputOwnership(has_server_camera=False)
     a_track = FakeTrack(frames=["a1"], ends=False)  # one frame, then silent forever
     pc_a = FakePC("connected")
@@ -162,11 +163,43 @@ async def test_owner_gap_with_waiter_yields_input():
     pc_b = FakePC("connected")
     sb = own.register_waiter(pc_b)
 
-    # A silent > gap with B waiting → A yields; its task finishes and releases.
-    await asyncio.wait_for(task_a, timeout=2)
-    assert not own.owner_is(pc_a)
+    # A silent > gap with B waiting → A yields ownership.
+    await asyncio.wait_for(_wait(lambda: not own.owner_is(pc_a)), timeout=2)
     # B is now the oldest remaining waiter and can claim.
     assert own.try_claim(sb, pc_b) is True
+    # A rejoined as a waiter — still draining, not done (V9).
+    assert not task_a.done()
+    assert own.num_waiters() == 2  # B (owner) + rejoined A
+
+    task_a.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task_a
+
+
+async def test_yielded_owner_reclaims_when_slot_frees():
+    # V9: after a gap-yield, the ex-owner sits as a waiter; when the new owner
+    # leaves and no one else waits, it reclaims (within ~its 1s claim poll).
+    own = InputOwnership(has_server_camera=False)
+    a_track = FakeTrack(frames=["a1"], ends=False)  # one frame, then silent forever
+    pc_a = FakePC("connected")
+    got, sink = _sink_recorder()
+    task_a = asyncio.ensure_future(
+        consume_peer_input(a_track, pc_a, own, sink, owner_gap_release=0.2)
+    )
+    await asyncio.wait_for(_wait(lambda: own.owner_is(pc_a)), timeout=2)
+
+    pc_b = FakePC("connected")
+    sb = own.register_waiter(pc_b)
+    await asyncio.wait_for(_wait(lambda: not own.owner_is(pc_a)), timeout=2)
+    assert own.try_claim(sb, pc_b) is True  # B takes over
+
+    own.release(sb, pc_b)  # B leaves — slot free, rejoined A is the only waiter
+    await asyncio.wait_for(_wait(lambda: own.owner_is(pc_a)), timeout=3)
+    assert not task_a.done()
+
+    task_a.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task_a
 
 
 async def test_owner_gap_no_waiter_holds():

--- a/tests/webrtc/test_consume_peer_input.py
+++ b/tests/webrtc/test_consume_peer_input.py
@@ -145,6 +145,75 @@ async def test_oldest_waiter_takes_over_when_owner_releases():
     assert own.num_waiters() == 0  # B's finally released its slot on cancel
 
 
+async def test_owner_gap_with_waiter_yields_input():
+    # Owner A stops delivering frames while publisher B waits. A must yield within
+    # ~the gap so B takes over — NOT wait out ICE consent expiry (~30s). This is
+    # the fast dead-owner path (V3).
+    own = InputOwnership(has_server_camera=False)
+    a_track = FakeTrack(frames=["a1"], ends=False)  # one frame, then silent forever
+    pc_a = FakePC("connected")
+    got, sink = _sink_recorder()
+    task_a = asyncio.ensure_future(
+        consume_peer_input(a_track, pc_a, own, sink, owner_gap_release=0.2)
+    )
+    await asyncio.wait_for(_wait(lambda: own.owner_is(pc_a)), timeout=2)
+
+    # B registers as a ready takeover candidate.
+    pc_b = FakePC("connected")
+    sb = own.register_waiter(pc_b)
+
+    # A silent > gap with B waiting → A yields; its task finishes and releases.
+    await asyncio.wait_for(task_a, timeout=2)
+    assert not own.owner_is(pc_a)
+    # B is now the oldest remaining waiter and can claim.
+    assert own.try_claim(sb, pc_b) is True
+
+
+async def test_owner_gap_no_waiter_holds():
+    # A lone owner is NEVER gap-evicted, no matter how long the gap (V2 / c855950).
+    own = InputOwnership(has_server_camera=False)
+    a_track = FakeTrack(frames=["a1"], ends=False)  # one frame, then silent forever
+    pc_a = FakePC("connected")
+    got, sink = _sink_recorder()
+    task = asyncio.ensure_future(
+        consume_peer_input(a_track, pc_a, own, sink, owner_gap_release=0.2)
+    )
+    await asyncio.wait_for(_wait(lambda: own.owner_is(pc_a)), timeout=2)
+
+    await asyncio.sleep(0.6)  # 3x the gap, but no other waiter exists
+    assert own.owner_is(pc_a) is True
+    assert not task.done()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+async def test_owner_delivering_frames_with_waiter_not_evicted():
+    # An owner still delivering frames is never yielded, even with a waiter present
+    # — the gap policy keys on a receive GAP, not on the mere presence of a waiter
+    # (V5).
+    own = InputOwnership(has_server_camera=False)
+    a_track = FakeTrack(frames=[f"a{i}" for i in range(200)], gap=0.02, ends=False)
+    pc_a = FakePC("connected")
+    got, sink = _sink_recorder()
+    task = asyncio.ensure_future(
+        consume_peer_input(a_track, pc_a, own, sink, owner_gap_release=0.2)
+    )
+    await asyncio.wait_for(_wait(lambda: own.owner_is(pc_a)), timeout=2)
+
+    pc_b = FakePC("connected")
+    own.register_waiter(pc_b)  # waiter present the whole time
+
+    await asyncio.sleep(0.6)  # 3x the gap, but A keeps delivering (0.02s << 0.2s)
+    assert own.owner_is(pc_a) is True
+    assert len(got) > 5
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
 async def _wait(pred, interval=0.01):
     while not pred():
         await asyncio.sleep(interval)

--- a/tests/webrtc/test_input_ownership.py
+++ b/tests/webrtc/test_input_ownership.py
@@ -1,0 +1,98 @@
+"""Unit tests for InputOwnership — the input-steering state machine.
+
+No aiortc / FastAPI / GPU. `pc` is any object identity.
+"""
+
+from fluxrt.webrtc.input_ownership import InputOwnership
+
+
+def _pc(name):
+    return type("PC", (), {"name": name})()
+
+
+def test_single_peer_claims_and_activates():
+    own = InputOwnership(has_server_camera=True)
+    a = _pc("a")
+    seq = own.register_waiter(a)
+    assert own.try_claim(seq, a) is True
+    assert own.owner_is(a) is True
+    assert own.is_active() is True
+    assert own.num_waiters() == 1
+
+
+def test_only_oldest_seq_claims():
+    own = InputOwnership()
+    a, b = _pc("a"), _pc("b")
+    sa = own.register_waiter(a)
+    sb = own.register_waiter(b)
+    assert sb > sa
+    # b cannot claim while a (older) is waiting
+    assert own.try_claim(sb, b) is False
+    assert own.try_claim(sa, a) is True
+    assert own.owner_is(a) is True
+    # b still cannot claim while a owns
+    assert own.try_claim(sb, b) is False
+
+
+def test_release_clears_active_when_idle():
+    own = InputOwnership(has_server_camera=True)
+    a = _pc("a")
+    sa = own.register_waiter(a)
+    own.try_claim(sa, a)
+    outcome = own.release(sa, a)
+    assert outcome.had_owner is True
+    assert outcome.became_idle is True
+    assert outcome.server_camera_resumes is True
+    assert own.is_active() is False
+    assert own.num_waiters() == 0
+
+
+def test_release_no_server_camera_does_not_resume():
+    own = InputOwnership(has_server_camera=False)
+    a = _pc("a")
+    sa = own.register_waiter(a)
+    own.try_claim(sa, a)
+    outcome = own.release(sa, a)
+    assert outcome.became_idle is True
+    assert outcome.server_camera_resumes is False
+
+
+def test_release_keeps_active_while_a_waiter_remains():
+    own = InputOwnership()
+    a, b = _pc("a"), _pc("b")
+    sa = own.register_waiter(a)
+    sb = own.register_waiter(b)
+    own.try_claim(sa, a)
+    # owner a leaves but waiter b is still registered
+    outcome = own.release(sa, a)
+    assert outcome.had_owner is True
+    assert outcome.became_idle is False  # b remains
+    assert own.is_active() is True  # NOT cleared — no server-camera flicker
+    # b now becomes the oldest and can claim
+    assert own.try_claim(sb, b) is True
+    assert own.owner_is(b) is True
+
+
+def test_handoff_to_oldest_waiter():
+    own = InputOwnership()
+    a, b, c = _pc("a"), _pc("b"), _pc("c")
+    sa, sb, sc = (own.register_waiter(x) for x in (a, b, c))
+    own.try_claim(sa, a)
+    own.release(sa, a)
+    # oldest remaining is b
+    assert own.try_claim(sc, c) is False
+    assert own.try_claim(sb, b) is True
+
+
+def test_waiter_release_without_ownership_is_clean():
+    own = InputOwnership()
+    a, b = _pc("a"), _pc("b")
+    sa = own.register_waiter(a)
+    sb = own.register_waiter(b)
+    own.try_claim(sa, a)
+    # b never owned; releasing it just pops its seq, ownership of a untouched
+    outcome = own.release(sb, b)
+    assert outcome.had_owner is False
+    assert own.owner_is(a) is True
+    assert own.is_active() is True
+    assert own.num_waiters() == 1

--- a/tests/webrtc/test_input_ownership.py
+++ b/tests/webrtc/test_input_ownership.py
@@ -3,11 +3,55 @@
 No aiortc / FastAPI / GPU. `pc` is any object identity.
 """
 
-from fluxrt.webrtc.input_ownership import InputOwnership
+import pytest
+
+from fluxrt.webrtc.input_ownership import (
+    OWNER_GAP_WITH_WAITER,
+    InputOwnership,
+    owner_gap_should_release,
+)
 
 
 def _pc(name):
     return type("PC", (), {"name": name})()
+
+
+@pytest.mark.parametrize(
+    "gap,others,expect",
+    [
+        (OWNER_GAP_WITH_WAITER, 1, True),       # exactly at threshold, waiter → yield
+        (OWNER_GAP_WITH_WAITER + 0.1, 2, True), # past threshold, multiple waiters
+        (OWNER_GAP_WITH_WAITER - 0.1, 1, False),# below threshold → keep
+        (1000.0, 0, False),                     # huge gap but NO waiter → keep (c855950-safe)
+        (0.0, 1, False),                        # waiter but no gap yet → keep
+    ],
+)
+def test_owner_gap_should_release(gap, others, expect):
+    assert owner_gap_should_release(gap, others) is expect
+
+
+@pytest.mark.parametrize(
+    "gap,others,threshold,expect",
+    [
+        (0.2, 1, 0.2, True),   # injected threshold (test-speed) honored
+        (0.1, 1, 0.2, False),  # below injected threshold
+        (100.0, 0, 0.2, False),# no waiter → keep regardless of threshold
+    ],
+)
+def test_owner_gap_should_release_custom_threshold(gap, others, threshold, expect):
+    assert owner_gap_should_release(gap, others, threshold) is expect
+
+
+def test_num_other_waiters_excludes_self():
+    own = InputOwnership()
+    a, b, c = _pc("a"), _pc("b"), _pc("c")
+    sa = own.register_waiter(a)
+    own.try_claim(sa, a)  # a owns but stays registered in _waiters
+    own.register_waiter(b)
+    own.register_waiter(c)
+    assert own.num_other_waiters(a) == 2  # b, c — a excludes itself
+    assert own.num_other_waiters(b) == 2  # a (owner), c
+    assert own.num_other_waiters(_pc("unknown")) == 3  # all three
 
 
 def test_single_peer_claims_and_activates():

--- a/tests/webrtc/test_reap_process.py
+++ b/tests/webrtc/test_reap_process.py
@@ -1,0 +1,69 @@
+"""Tests for reap_process — the bounded subprocess kill ladder + the
+multiprocessing._children detach that prevents the no-timeout atexit-join hang.
+"""
+
+import multiprocessing as mp
+
+import _child_targets
+import psutil
+
+from fluxrt.webrtc.proc import reap_process
+
+
+def _spawn(ignore_sigterm):
+    ctx = mp.get_context("spawn")
+    p = ctx.Process(target=_child_targets.busy_child, args=(ignore_sigterm,))
+    p.start()
+    return p
+
+
+def test_reap_killable_child():
+    p = _spawn(ignore_sigterm=False)
+    assert psutil.pid_exists(p.pid)
+    ok = reap_process(p, join_timeouts=(0.2, 0.5, 1.0))
+    assert ok is True
+    assert not p.is_alive()
+
+
+def test_reap_sigterm_ignoring_child_escalates_to_sigkill():
+    p = _spawn(ignore_sigterm=True)  # ignores SIGTERM -> terminate() is a no-op
+    assert psutil.pid_exists(p.pid)
+    ok = reap_process(p, join_timeouts=(0.2, 0.3, 1.5))
+    assert ok is True, "SIGKILL escalation should reap a SIGTERM-ignoring child"
+    assert not p.is_alive()
+
+
+class _ImmortalProc:
+    """A process that never dies — to exercise the survivor-detach path."""
+
+    def __init__(self):
+        self.pid = 2_147_483_001  # almost certainly nonexistent; os.kill -> suppressed
+        self.terminated = 0
+        self.killed = 0
+
+    def is_alive(self):
+        return True
+
+    def join(self, timeout=None):
+        return None
+
+    def terminate(self):
+        self.terminated += 1
+
+    def kill(self):
+        self.killed += 1
+
+
+def test_survivor_is_detached_from_multiprocessing_children():
+    import multiprocessing.process as mpp
+
+    fake = _ImmortalProc()
+    mpp._children.add(fake)  # simulate a registered, unkillable child
+    try:
+        ok = reap_process(fake, join_timeouts=(0, 0, 0))
+        assert ok is False
+        assert fake.terminated == 1 and fake.killed == 1
+        # The whole point: removed so atexit's no-timeout join can't block on it.
+        assert fake not in mpp._children
+    finally:
+        mpp._children.discard(fake)

--- a/tests/webrtc/test_recv_policy.py
+++ b/tests/webrtc/test_recv_policy.py
@@ -1,0 +1,62 @@
+"""Regression guard for the c855950 hang.
+
+c855950 evicted the input owner on a blind 5s recv() timeout regardless of
+connection state, freezing a healthy owner whose inter-frame gap exceeded 5s
+(first keyframe, TURN/DTLS settle, brief stall). These assertions encode the
+fix: an owner is released ONLY on a terminal connection state; a connected peer
+is never gap-evicted.
+"""
+
+import pytest
+
+from fluxrt.webrtc.input_ownership import (
+    owner_should_release,
+    waiter_should_evict,
+)
+
+
+def test_owner_not_released_when_connected():
+    # THE regression guard: a healthy connected owner with a long frame gap stays.
+    assert owner_should_release("connected") is False
+
+
+@pytest.mark.parametrize("state", ["failed", "closed", "disconnected"])
+def test_owner_released_only_on_terminal_state(state):
+    assert owner_should_release(state) is True
+
+
+def test_waiter_connected_is_never_evicted_even_past_deadline():
+    assert (
+        waiter_should_evict(
+            connection_state="connected", got_first_frame=False, deadline_passed=True
+        )
+        is False
+    )
+
+
+def test_waiter_dead_and_past_deadline_is_evicted():
+    assert (
+        waiter_should_evict(
+            connection_state="failed", got_first_frame=False, deadline_passed=True
+        )
+        is True
+    )
+
+
+def test_waiter_not_evicted_before_deadline():
+    assert (
+        waiter_should_evict(
+            connection_state="failed", got_first_frame=False, deadline_passed=False
+        )
+        is False
+    )
+
+
+def test_waiter_with_a_frame_is_never_gap_evicted():
+    # Once a frame arrived, the waiter is a real view-only peer; never drop it.
+    assert (
+        waiter_should_evict(
+            connection_state="failed", got_first_frame=True, deadline_passed=True
+        )
+        is False
+    )

--- a/tests/webrtc/test_stats.py
+++ b/tests/webrtc/test_stats.py
@@ -1,0 +1,30 @@
+"""Unit tests for the /healthz connection-pool stats helper."""
+
+from fluxrt.webrtc.stats import connection_pool_stats
+
+
+def test_empty_pool():
+    s = connection_pool_stats([])
+    assert s == {"total": 0, "active": 0, "by_state": {}}
+
+
+def test_counts_and_active():
+    s = connection_pool_stats(
+        ["connected", "connected", "connecting", "failed"]
+    )
+    assert s["total"] == 4
+    assert s["active"] == 2  # only "connected" counts as active
+    assert s["by_state"] == {"connected": 2, "connecting": 1, "failed": 1}
+
+
+def test_none_state_becomes_unknown():
+    s = connection_pool_stats([None, "connected"])
+    assert s["total"] == 2
+    assert s["active"] == 1
+    assert s["by_state"]["unknown"] == 1
+
+
+def test_by_state_ordered_by_lifecycle_then_alpha():
+    s = connection_pool_stats(["closed", "new", "connected", "zzz"])
+    # known states in lifecycle order first, unknown extras ("zzz") last
+    assert list(s["by_state"].keys()) == ["new", "connected", "closed", "zzz"]


### PR DESCRIPTION
## Problem

A publishing peer that dies abruptly (network loss, killed tab) keeps its aiortc pc in `connected` until ICE consent expiry (aioice `CONSENT_INTERVAL=5 × CONSENT_FAILURES=6` ≈ 25–35s), freezing the pipeline input the whole time — even when another client is queued to drive. aiortc never emits `connectionState == "disconnected"` (explicit note in its source), so the existing `connectionstatechange` handler cannot shorten this.

## Fix — waiter-conditioned gap handoff

- `owner_gap_should_release(gap_s, other_waiters, threshold)` (pure): owner yields **only** when silent ≥ `OWNER_GAP_WITH_WAITER` (8s) **and** another publisher waits. A lone owner is never gap-evicted — the c855950 guard holds (paused camera / slow keyframe legit).
- `_pump_owner_frames` supervises the receive gap (1s poll; healthy owners never hit it).
- Gap-yielded peer **rejoins as the newest waiter** (V9): its track keeps being drained — aiortc decodes inbound RTP into an unbounded queue regardless of `recv()` — and it can reclaim when the slot frees. (Caught in self-review as B1: the first cut returned with an alive pc and left the track undrained → ~12MB/s queue growth if the camera resumed.)
- Waiter claim poll capped at 1s (was up to a 25s recv block for a silent/stalled waiter) — handoff/reclaim latency now ≤ ~1s after the slot frees; first-frame eviction deadline unchanged.
- Comment fix in `run_webrtc.py` re aiortc states (no behavior change).

Worst-case dead-owner → waiter handoff: ~10s (8 threshold + 1 poll + 1 claim), vs ~30s before.

## Spec

`SPEC.md` (new, cavekit format): §V1–V9 invariants, §B1 backprop entry. Companion client PR: 204-ai/realtime-client (engine reconnect grace + per-clip input role).

## Tests

`pytest tests/webrtc/` → **40 passed** (13 new): pure-policy table (incl. injected threshold), gap+waiter handoff, lone-owner holds, delivering-owner-not-evicted, rejoin+reclaim, num_other_waiters excludes self. Torch/aiortc/GPU-free harness.

Manual e2e still pending: two publisher tabs vs live server, kill one's network (devtools offline) → other gets `input:you` ≤ ~10s (`/healthz` `input_waiters`/`input_source`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)